### PR TITLE
Disallow asterisks in Earthstar paths

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -27,6 +27,7 @@ Document version: 2020-08-09.1
 - [Paths and Write Permissions](#paths-and-write-permissions)
   - [Paths](#paths)
   - [Path Characters With Special Meaning](#path-characters-with-special-meaning)
+  - [Disallowed Path Characters](#disallowed-path-characters)
   - [Write Permissions](#write-permissions)
   - [Path and Filename Conventions](#path-and-filename-conventions)
 - [Documents and Their Fields](#documents-and-their-fields)
@@ -367,7 +368,7 @@ Similar to a key in leveldb or a path in a filesystem, each document is stored a
 Rules:
 
 ```
-PATH_PUNCTUATION = "/'()-._~!*$&+,:=@%"  // double quote is not included
+PATH_PUNCTUATION = "/'()-._~!$&+,:=@%"  // double quote is not included
 PATH_CHARACTER = ALPHA_LOWER + ALPHA_UPPER + DIGIT + PATH_PUNCTUATION
 
 PATH_SEGMENT = "/" PATH_CHARACTER+
@@ -434,10 +435,26 @@ Invalid: starts with "/@"
 ## Path Characters With Special Meaning
 
 * `/` - starts paths; separates path segments
-* `~` - defines author write permissions
 * `!` - used if and only if the document is ephemeral
+* `~` - defines author write permissions
 * `%` - for percent-encoding other characters
-* `*` - allowed, but it might someday be used in path queries, so consider avoiding it
+* `+@.` - used in workspace and author addresses but allowed elsewhere too
+
+## Disallowed Path Characters
+
+See the source code `src/util/characters.ts` for longer notes about this.
+
+* space           - not allowed in URLs
+* `<>"[\]^{|}`    - not allowed in URLs
+* backtick        - not allowed in URLs
+* `?`             - to avoid confusion with URL query parameters
+* `#`             - to avoid confusion with URL anchors
+* `;`             - no reason
+* `*`             - no reason; maybe useful for querying in the future
+* non-ASCII chars - to avoid trouble with Unicode normalization
+* ASCII whitespace (tab, etc)
+* ASCII control characters (bell, etc)
+
 
 ## Write Permissions
 

--- a/src/test/validator.es4.test.ts
+++ b/src/test/validator.es4.test.ts
@@ -375,7 +375,7 @@ t.test('_checkPathIsValid', (t: any) => {
         { valid: true, path: '/a/b/c/d/e/f/g/h' },
         { valid: true, path: '/about/~@suzy.abc/name' },
         { valid: true, path: '/wiki/shared/Garden%20Gnome' },
-        { valid: true, path: '/\'()-._~!*$&+,:=@%', note: 'all allowed punctuation characters' },
+        { valid: true, path: '/\'()-._~!$&+,:=@%', note: 'all allowed punctuation characters' },
 
         // ephemeral documents and '!'
         { valid: true, path: '/foo', deleteAfter: null, note: 'proper regular path with no !' },
@@ -418,10 +418,10 @@ t.test('_checkPathIsValid', (t: any) => {
         { valid: false, path: '/pipe|' },
         { valid: false, path: '/open-curly-bracket{' },
         { valid: false, path: '/close-curly-bracket}' },
-
         { valid: false, path: '/question-mark?' },
         { valid: false, path: '/pound#' },
         { valid: false, path: '/semicolon;' },
+        { valid: false, path: '/asterisk*' },
 
         { valid: false, path: '/newline\n' },
         { valid: false, path: '/tab\t' },

--- a/src/util/characters.ts
+++ b/src/util/characters.ts
@@ -42,9 +42,7 @@ export const workspaceAddressChars = workspaceNameChars + b32chars + '+.';
 // Allowed      Earthstar Meaning
 //    a-zA-Z0-9    no meaning
 //    '()-_$&,:=   no meaning
-//    *            no meaning, but some apps might use for querying paths, so
-//                   consider avoiding '*' in your paths
-//    /            path separator
+//    /            starts paths; path segment separator
 //    !            ephemeral docs must contain at least one '!'
 //    ~            denotes path ownership (write permissions)
 //    +@.          used by workspace and author names but allowed elsewhere too
@@ -55,7 +53,8 @@ export const workspaceAddressChars = workspaceNameChars + b32chars + '+.';
 //    <>"[\]^`{|}      not allowed in URLs (though some browsers allow some of them)
 //    ?                to avoid confusion with URL query parameters
 //    #                to avoid confusion with URL anchors
-//    ;                to have one URL-legal char that's not a valid Earthstar path char
+//    ;                no reason
+//    *                no reason; maybe useful for querying in the future
 //    non-ASCII chars  to avoid trouble with Unicode normalization
 //    ASCII whitespace
 //    ASCII control characters
@@ -70,7 +69,7 @@ export const workspaceAddressChars = workspaceNameChars + b32chars + '+.';
 //      for display to users again, run decodeURI(earthstarPath)
 //
 
-export const pathPunctuation = "/'()-._~!*$&+,:=@%";  // note double quotes are not included
+export const pathPunctuation = "/'()-._~!$&+,:=@%";  // note double quotes are not included
 export const pathChars = alphaLower + alphaUpper + digits + pathPunctuation;
 
 


### PR DESCRIPTION
We might want to use asterisks for querying in the future, perhaps in [earthstar-fetch](https://github.com/earthstar-project/earthstar-fetch/) / [Agregore](https://github.com/AgregoreWeb/agregore-browser).  So I'm excluding them from Earthstar paths.

Also expanded the documentation about the disallowed characters.