### PR TITLE
Fix bug with undefined history field in queries; add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test-detRandom": "tap -Rspecy --jobs=1 build/test/detRandom.test.js",
     "test-emitter": "tap -Rspecy --jobs=1 build/test/emitter.test.js",
     "test-extras": "tap -Rspecy --jobs=1 build/test/extras.test.js",
+    "test-helpers": "tap -Rspecy --jobs=1 build/test/helpers.test.js",
     "test-query": "tap -Rspecy --jobs=1 build/test/query.test.js",
     "test-storageAsync": "tap -Rspecy --jobs=1 build/test/storageAsync.test.js",
     "test-syncWithChannels": "tap -Rspecy --jobs=1 build/test/syncWithChannels.test.js",

--- a/src/storage/query.ts
+++ b/src/storage/query.ts
@@ -4,6 +4,9 @@ import {
     isErr,
     ValidationError
 } from '../util/types';
+import {
+    objWithoutUndefined
+} from '../util/helpers';
 
 /*
 open questions
@@ -28,6 +31,10 @@ export type HistoryMode =
  * HISTORY MODES
  * - `latest`: get latest docs, THEN filter those.
  * - `all`: get all docs, THEN filter those.
+ * 
+ * A property set to undefined is equivalent to not setting
+ * that property at all, because cleanUpQuery(q) removes those
+ * properties.
  */
 export interface Query {
     //=== filters that affect all documents equally within the same path
@@ -153,8 +160,13 @@ export let cleanUpQuery = (query: Query): Query => {
     }
     // set defaults
     let q: Query = {
+        // this is the only default we have so far
         history: 'latest',
-        ...query
+        
+        // remove undefined properties from the original query --
+        // both as a general clean-up, and to prevent them
+        // from shadowing our defaults (above).
+        ...objWithoutUndefined(query),
     };
     return q;
 }

--- a/src/test/helpers.test.ts
+++ b/src/test/helpers.test.ts
@@ -1,0 +1,85 @@
+import t = require('tap');
+import { __makeTemplateObject } from 'tslib';
+//t.runOnly = true;
+
+import {
+    isPlainObject,
+    objWithoutUndefined,
+    range,
+    sorted,
+    stringMult,
+    uniq,
+} from '../util/helpers';
+
+//================================================================================
+
+t.test('isPlainObject', (t: any) => {
+    class DogClass {
+        constructor(public name: string) {
+        }
+    }
+
+    t.ok(isPlainObject({}), 'an actual object');
+
+    // this is a questionable result, should a class instance
+    // be considered a plain object?
+    t.ok(isPlainObject(new DogClass('Fido')), 'a class instance');
+
+    // things that are not plain objects
+    t.notOk(isPlainObject(DogClass), 'a class itself');
+    t.notOk(isPlainObject(false), 'false');
+    t.notOk(isPlainObject([]), 'array');
+    t.notOk(isPlainObject(null), 'null');
+    t.notOk(isPlainObject(undefined), 'undefined');
+    t.notOk(isPlainObject('hello'), 'string');
+
+    t.done();
+});
+
+t.test('range', (t: any) => {
+    t.same(range(0), []);
+    t.same(range(1), [0]);
+    t.same(range(2), [0, 1]);
+    t.same(range(3), [0, 1, 2]);
+    t.done();
+});
+
+t.test('stringMult', (t: any) => {
+    t.same(stringMult('x', 5), 'xxxxx');
+    t.same(stringMult('abc', 2), 'abcabc');
+    t.same(stringMult('f', 0), '');
+    t.same(stringMult('- ', 3), '- - - ');
+    t.done();
+});
+
+t.test('uniq', (t: any) => {
+    let words = 'z apple banana apple cherry cupcake grape grape z'.split(' ');
+    let uniqued = 'z apple banana cherry cupcake grape'.split(' ');
+    t.same(uniq(words), uniqued);
+    t.same(uniq([]), []);
+    t.same(uniq(['a']), ['a']);
+    t.done();
+});
+
+t.test('sorted', (t: any) => {
+    let words = 'z apple banana cherry cupcake grape'.split(' ');
+    let correctlySorted = 'apple banana cherry cupcake grape z'.split(' ');
+    let result = sorted(words);
+    t.same(result, correctlySorted);
+    t.same(words[0], 'apple', 'original was modified');
+    t.done();
+});
+
+t.test('objWithoutUndefined', (t: any) => {
+    let cases: [any, any][] = [
+        // input, desired output
+        [{a: 1}, {a: 1}],
+        [{a: 1, b: undefined}, {a: 1}],
+        [{b: undefined}, {}],
+    ]
+    for (let [inpt, goal] of cases) {
+        let result = objWithoutUndefined(inpt);
+        t.same(result, goal);
+    }
+    t.done();
+});

--- a/src/test/query.test.ts
+++ b/src/test/query.test.ts
@@ -145,6 +145,22 @@ t.test('cleanUpQuery', (t: any) => {
         {
             query: {},
             result: { history: 'latest' },
+            note: 'history mode is set to default if omitted'
+        },
+        {
+            query: { history: 'all' },
+            result: { history: 'all' },
+            note: 'history mode is respected if provided'
+        },
+        {
+            query: { path: undefined },
+            result: { history: 'latest' },
+            note: 'undefined options go away if they have no defaults',
+        },
+        {
+            query: { path: '/hello', history: undefined },
+            result: { path: '/hello', history: 'latest' },
+            note: 'undefined options are not able to shadow default values',
         },
         {
             query: { history: '???' } as any,

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,18 +1,28 @@
 export let isPlainObject = (obj : any) : obj is object =>
+    // Check if the input is a plain object type { ... }
+    // Exclude arrays, undefined, etc.
+    // For now class instances count as plain objects (is this a bug?)
     Object.prototype.toString.call(obj) === '[object Object]'
 
 export let range = (n : number) : number[] =>
-    // [0, 1, ... n-1]
+    // Make an array of n consecutive integers starting with zero.
+    //   range(n) --> [0, 1, ... n-1]
     [...Array(n).keys()]
 
-// stringMult('a!', 3) === 'a!a!a!'
 export let stringMult = (str : string, n : number) : string =>
+    // Repeat a string a given number of times.
+    //   stringMult('a!', 3) --> 'a!a!a!'
     range(n).map(x => str).join('')
 
 export let sleep = async (ms : number) : Promise<void> =>
+    // Return a promise that resolves after a given number of millisceconds
     new Promise((resolve, reject) => setTimeout(resolve, ms) );
 
 export let uniq = (items: string[]) : string[] => {
+    // Given an array of strings,
+    // return a new array of unique strings
+    // (in the same order as the first occurrance of
+    // each string).
     let map : Record<string, boolean> = {};
     for (let item of items) {
         map[item] = true;
@@ -20,6 +30,23 @@ export let uniq = (items: string[]) : string[] => {
     return Object.keys(map);
 }
 export let sorted = <T>(items: T[]) : T[] => {
+    // Sort an array, mutating it in place,
+    // and return it.
     items.sort();
     return items;
+}
+
+export let objWithoutUndefined = <T extends Record<string, any>>(obj: T): T => {
+    // Given an object, return a copy of the object
+    // which omits any undefined keys.
+    // Does not mutate the original object.
+    // Example:
+    //   objWithoutUndefined({ a:1, b: undefined }) --> { a:1 }
+    let obj2: any = {};
+    for (let [key, val] of Object.entries(obj)) {
+        if (val !== undefined) {
+            obj2[key] = val;
+        }
+    }
+    return obj2 as T;
 }


### PR DESCRIPTION
## What's the problem you solved?

Resolves #68 "Ignore an undefined value when validating query.history"

## What solution are you recommending?

There was a `cleanUpQuery(q)` function which was supposed to canonicalize query objects, but it had a bug.  Queries have default values for some parameters, currently only `history`.  If the incoming query had `history: undefined`, that undefined value would win over the default value.

Fixed by removing all undefined key-value pairs from query objects before merging with the defaults.  This should also remove any other stray undefined keys from queries as well, which would have been a good idea in the first place. :)

Added a helper to remove undefined items from objects: `objWithoutUndefined(obj)` in `util/helpers.ts`.

I noticed that none of the helpers there had tests, so I wrote tests for all of them.