### PR TITLE
Add IStorageAsync support to a few syncing classes and functions

### DIFF
--- a/src/storage/storageToAsync.ts
+++ b/src/storage/storageToAsync.ts
@@ -28,6 +28,7 @@ import { Emitter } from '../util/emitter';
  * `fakeSleepTime` is an optional delay in ms that's added into each call,
  * for testing purposes.
  */
+ 
 export class StorageToAsync implements IStorageAsync {
     readonly workspace : WorkspaceAddress;
     readonly sessionId: string;  // gets a new random value every time the program runs

--- a/src/test/syncer1.test.ts
+++ b/src/test/syncer1.test.ts
@@ -19,7 +19,8 @@ import {
     SyncState,
     Syncer1,
 } from '../sync/syncer1';
-import { IStorage } from '../storage/storageTypes';
+import { IStorage, IStorageAsync } from '../storage/storageTypes';
+import { StorageToAsync } from '../storage/storageToAsync';
 
 //================================================================================
 // prepare for test scenarios
@@ -39,14 +40,14 @@ let author2: AuthorAddress = keypair2.address;
 let author3: AuthorAddress = keypair3.address;
 let now = 1500000000000000;
 
-let makeStorage = (workspace : string) : IStorage =>
-    new StorageMemory(VALIDATORS, workspace);
+let makeStorage = (workspace : string) : IStorageAsync =>
+    new StorageToAsync(new StorageMemory(VALIDATORS, workspace), 0);
 
 //================================================================================
 t.test('Syncer basics and callback subscriptions', (t: any) => {
     let storage = makeStorage(WORKSPACE);
     let syncer = new Syncer1(storage);
-
+    
     let numCalls = 0;
     let lastCallbackVal : SyncState | null = null;
     let unsub = syncer.onChange.subscribe(st => {


### PR DESCRIPTION
Adds `IStorageAsync` support to:

- `Syncer1`
- `syncLocalAndHttp`
- `OnePubOneWorkspaceSyncer`

Because `IStorage` and `IStorageAsync` are nearly the same, save for that pesky async bit, I achieved this in a bit of cheeky way: adding `await` before calls to `storage`, even when it might be `IStorage`.

I _think_ this covers all the public syncing utilities which did not have Async support. I could be wrong!

This would solve #71.
