### PR TITLE
PR on PR for logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,6 @@ export * from './util/characters';
 export * from './util/detRandom';
 export * from './util/emitter';
 export * from './util/helpers';
-export { setLogLevels } from './util/log'
+export * from './util/log'
 export * from './util/types';
 export * from './validator/es4';

--- a/src/storage/storageSqlite.ts
+++ b/src/storage/storageSqlite.ts
@@ -23,6 +23,7 @@ import {
 } from './storageBase';
 
 import Logger from '../util/log';
+const storageLogger = new Logger('storage')
 
 //================================================================================
 
@@ -48,8 +49,6 @@ import Logger from '../util/log';
  * ```
  */
 
-const storageLogger = new Logger('storage')
- 
 interface StorageSqliteOptsCreate {
     mode: 'create'
     workspace: WorkspaceAddress,

--- a/src/sync/syncWithChannels.ts
+++ b/src/sync/syncWithChannels.ts
@@ -18,12 +18,9 @@ import {
     IStorage,
 } from '../storage/storageTypes';
 
-import { StorageToAsync } from '../storage/storageToAsync';
-import { StorageMemory } from '../storage/storageMemory';
-import { ValidatorEs4 } from '../validator/es4';
 import Logger from '../util/log';
 
-const syncLogger = new Logger('sync')
+const syncLogger = new Logger('syncWithChannels')
 
 let logSyncMain     = (msg: string) => syncLogger.log(chalk.whiteBright(msg));
 let logSyncThread   = (msg: string) => syncLogger.log(chalk.white(      msg));
@@ -499,7 +496,7 @@ export let incrementalSync = async (storage1: IStorageAsync | IStorage, storage2
     // make sure all channels were closed, to check for bugs
     for (let chan of chans) {
         if (!chan.isClosed) {
-            console.warn('== incrementalSync WARNING: a channel was not closed');
+            syncLogger.warn('== incrementalSync WARNING: a channel was not closed');
             chan.close();
         }
     }

--- a/src/sync/syncer1.ts
+++ b/src/sync/syncer1.ts
@@ -10,6 +10,9 @@ import { IStorage } from '../storage/storageTypes';
 import { sleep } from '../util/helpers';
 import Logger from '../util/log'
 
+const syncer1Logger = new Logger('syncer1 💚')
+const syncerHttpLogger = new Logger('sync http alg 🌲')
+
 // sync states
 //  idle      sync has not been attempted since page load
 //  syncing   syncing is happening now
@@ -32,9 +35,9 @@ let ensureTrailingSlash = (url : string) : string =>
     // input is a URL with no path, like https://mypub.com or https://mypub.com/
     url.endsWith('/') ? url : url + '/';
 
-const syncLogger = new Logger('sync')
 
-let logSyncer = (...args : any[]) => syncLogger.log('💚 syncer | ', ...args);
+// Manage pubs and syncing state.
+// Defer to the SyncLocalAndHttp class for the nitty-gritty details.
 export class Syncer1 {
     storage : IStorage;
     onChange : Emitter<SyncState>;
@@ -71,7 +74,7 @@ export class Syncer1 {
         this.onChange.send(this.state);
     }
     async sync() {
-        logSyncer('starting');
+        syncer1Logger.log('starting');
         this.state.syncState = 'syncing';
         this.onChange.send(this.state);
         let numSuccessfulPubs = 0;
@@ -80,7 +83,7 @@ export class Syncer1 {
         let syncPromises : {prom: Promise<any>, pub: any}[] = [];
         // start each pub syncing
         for (let pub of this.state.pubs) {
-            logSyncer('starting pub:', pub.domain);
+            syncer1Logger.log('starting pub:', pub.domain);
             pub.syncState = 'syncing';
             this.onChange.send(this.state);
 
@@ -92,8 +95,8 @@ export class Syncer1 {
         // when each one finishes (not necessarily in the same order), report its results
         for (let {prom, pub} of syncPromises) {
             let resultStats = await prom;
-            logSyncer('finished pub');
-            logSyncer(JSON.stringify(resultStats, null, 2));
+            syncer1Logger.log('finished pub');
+            syncer1Logger.log(JSON.stringify(resultStats, null, 2));
             if (resultStats.pull === null && resultStats.push === null) {
                 pub.syncState = 'failure';
                 numFailedPubs += 1;
@@ -108,7 +111,7 @@ export class Syncer1 {
         // wait a moment so the user can keep track of what's happening
         await sleep(150);
 
-        logSyncer('finished all pubs');
+        syncer1Logger.log('finished all pubs');
         this.state.lastSync = Date.now();
         if (numSuccessfulPubs > 0) { this.state.syncState = 'success'; }
         else if (numFailedPubs > 0) { this.state.syncState = 'failure'; }
@@ -117,16 +120,17 @@ export class Syncer1 {
     }
 }
 
-let urlGetDocuments = (domain : string, workspace : WorkspaceAddress) =>
+//================================================================================
+
+let urlToGetDocuments = (domain : string, workspace : WorkspaceAddress) =>
     // domain should already end in a slash.
     // output is like https://mypub.com/earthstar-api/v1/+gardening.xxxxxxxx/documents
     `${domain}earthstar-api/v1/${workspace}/documents`;
-let urlPostDocuments = urlGetDocuments;
+let urlToPostDocuments = urlToGetDocuments;
 
-let logSyncAlg = (...args : any[]) => syncLogger.log('  🌲  sync algorithm | ', ...args);
-
+// This is the actual HTTP syncing algorithm
 export let syncLocalAndHttp = async (storage : IStorage, domain : string) => {
-    logSyncAlg('existing database workspace:', storage.workspace);
+    syncerHttpLogger.log('existing database workspace:', storage.workspace);
     let resultStats : any = {
         pull: null,
         push: null,
@@ -136,13 +140,13 @@ export let syncLocalAndHttp = async (storage : IStorage, domain : string) => {
     // pull from server
     // this can 404 the first time, because the server only creates workspaces
     // when we push them
-    logSyncAlg('pulling from ' + domain);
+    syncerHttpLogger.log('pulling from ' + domain);
     let resp : any;
     try {
-        resp = await fetch(urlGetDocuments(domain, storage.workspace));
+        resp = await fetch(urlToGetDocuments(domain, storage.workspace));
     } catch (e) {
-        console.error('ERROR: could not connect to server');
-        console.error(e.toString());
+        syncerHttpLogger.error('ERROR: could not connect to server');
+        syncerHttpLogger.error(e.toString());
         return resultStats;
     }
     resultStats.pull = {
@@ -151,7 +155,7 @@ export let syncLocalAndHttp = async (storage : IStorage, domain : string) => {
         numTotal: 0,
     };
     if (resp.status === 404) {
-        logSyncAlg('    server 404: server does not know about this workspace yet');
+        syncerHttpLogger.warn('    server 404: server does not know about this workspace yet');
     } else {
         let docs = await resp.json();
         resultStats.pull.numTotal = docs.length;
@@ -159,30 +163,30 @@ export let syncLocalAndHttp = async (storage : IStorage, domain : string) => {
             if (storage.ingestDocument(doc, 'TODO: session id') === WriteResult.Accepted) { resultStats.pull.numIngested += 1; }
             else { resultStats.pull.numIgnored += 1; }
         }
-        logSyncAlg(JSON.stringify(resultStats.pull, null, 2));
+        syncerHttpLogger.log(JSON.stringify(resultStats.pull, null, 2));
     }
 
     // push to server
-    logSyncAlg('pushing to ' + domain);
+    syncerHttpLogger.log('pushing to ' + domain);
     let resp2 : any;
     try {
-        resp2 = await fetch(urlPostDocuments(domain, storage.workspace), {
+        resp2 = await fetch(urlToPostDocuments(domain, storage.workspace), {
             method: 'post',
             body:    JSON.stringify(storage.documents({ history: 'all' })),
             headers: { 'Content-Type': 'application/json' },
         });
     } catch (e) {
-        console.error('ERROR: could not connect to server');
-        console.error(e.toString());
+        syncerHttpLogger.error('ERROR: could not connect to server');
+        syncerHttpLogger.error(e.toString());
         return resultStats;
     }
     if (resp2.status === 404) {
-        logSyncAlg('    server 404: server is not accepting new workspaces');
+        syncerHttpLogger.warn('    server 404: server is not accepting new workspaces');
     } else if (resp2.status === 403) {
-        logSyncAlg('    server 403: server is in readonly mode');
+        syncerHttpLogger.warn('    server 403: server is in readonly mode');
     } else {
         resultStats.pushStats = await resp2.json();
-        logSyncAlg(JSON.stringify(resultStats.pushStats, null, 2));
+        syncerHttpLogger.log(JSON.stringify(resultStats.pushStats, null, 2));
     }
 
     return resultStats;

--- a/src/sync/syncer2.ts
+++ b/src/sync/syncer2.ts
@@ -19,7 +19,7 @@ import Logger from '../util/log';
 //================================================================================
 // HELPERS
 
-const syncLogger = new Logger('sync')
+const syncLogger = new Logger('syncer2')
 
 let logSyncer = (...args : any[])     => syncLogger.debug('💚 syncer | ', ...args);
 let logSync = (...args : any[])       => syncLogger.debug('  🌲  one pub: SYNC | ', ...args);
@@ -180,7 +180,7 @@ export class OnePubOneWorkspaceSyncer {
         this.pullStream = new EventSource(url);
         this.pullStream.onerror = (e) => {
             logPullStream('connection failed');
-            console.error(e);
+            syncLogger.error(e);
         }
         this.pullStream.onmessage = (e) => {
             // TODO: if (this.state.closed) { return; }
@@ -196,7 +196,7 @@ export class OnePubOneWorkspaceSyncer {
                 }
             } catch (e) {
                 logPullStream('error, probably bad json');
-                console.error(e);
+                syncLogger.error(e);
             }
         };
         this.state.isPullStreaming = true;

--- a/src/test/extras.test.ts
+++ b/src/test/extras.test.ts
@@ -14,11 +14,9 @@ import {
 } from '../storage/storageTypes';
 import {
     generateAuthorKeypair,
-    sha256base32,
 } from '../crypto/crypto';
 import { ValidatorEs4 } from '../validator/es4';
 import { StorageMemory } from '../storage/storageMemory';
-import { StorageSqlite } from '../storage/storageSqlite';
 
 import { deleteMyDocuments } from '../extras';
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -81,21 +81,21 @@ export default class Logger {
   debug(...args:  any[]) {    
     let allowedLevel = currentLogLevelSettings[this._source] ?? currentLogLevelSettings['_other'];
     if (allowedLevel >= LogLevel.Debug) {
-      console.error(`[${this._source} debug]`, ...args)
+      console.debug(`[${this._source} debug]`, ...args)
     }
   }
   
   log(...args:  any[]) {
     let allowedLevel = currentLogLevelSettings[this._source] ?? currentLogLevelSettings['_other'];
     if (allowedLevel >= LogLevel.Log) {
-      console.error(`[${this._source} log]`, ...args)
+      console.log(`[${this._source} log]`, ...args)
     }
   }
   
   warn(...args:  any[]) {
     let allowedLevel = currentLogLevelSettings[this._source] ?? currentLogLevelSettings['_other'];
     if (allowedLevel >= LogLevel.Warn) {
-      console.error(`[${this._source} warn]`, ...args)
+      console.warn(`[${this._source} warn]`, ...args)
     }
   }
   

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -1,31 +1,74 @@
-type LogSource = 'sync' | 'storage' 
+
+// Logs are assigned a priority number.
+// Higher numbers are less important information.
+// Set your desired log level higher to get more info.
+// -1 shows nothing.
+// 0 only shows errors.
+// 1 also shows warnings.
+// 2 also shows logs.
+// 3 also shows debugs.
+
+// Logs also come from different "sources" which can
+// have different log level settings.
+
+// Two ways to modify the log level settings:
+//
+// 1. Set an environment variable in the shell.
+//    This applies to all "sources" (can't be set individually)
+//         EARTHSTAR_LOG_LEVEL=2 npm run test
+//
+// 2. Use setLogLevels() to globally modify the levels:
+//         setLogLevels({ sync: 2 });
+//
+// The environment variable wins over the numbers set by setLogLevels.
+
+type LogSource = 'sync' | 'storage' | string;
 
 enum LogLevel {
-  Error,
-  Warn,
-  Log,
-  Debug
+  // Level 0, error, is enabled by default
+  // Set logLevel to -1 to hide errors.
+  Error = 0,
+  Warn = 1,
+  Log = 2,
+  Debug = 3,
 };
 
 type LogLevelSettings = Record<LogSource, LogLevel>
 
-function initLogLevel(defaultLevel: number): number {
+// get the single log level number from the environment, or undefined if not set
+function readEnvLogLevel(): number | undefined {
   if (process?.env?.EARTHSTAR_LOG_LEVEL) {
     const parsed = parseInt(process.env.EARTHSTAR_LOG_LEVEL);
-    
-    return parsed === NaN ? defaultLevel : parsed;
+    return parsed === NaN ? undefined : parsed;
   }
-  
-  return defaultLevel;
+  return undefined;
 }
+const envLogLevel = readEnvLogLevel();
 
-const logLevelSettings : LogLevelSettings = {
-  sync: initLogLevel(0),
-  storage: initLogLevel(0)
+// set up an env-levels overlay that will go on top of our
+// manually set logLevel settings from setLogLevels()
+const envLogLevels: Partial<LogLevelSettings> =
+  envLogLevel === undefined
+  ? {}
+  : {
+    sync: envLogLevel,
+    storage: envLogLevel,
+    _other: envLogLevel,
+};
+
+// set initial defaults to 1 (errors and warnings)
+let currentLogLevelSettings: LogLevelSettings = {
+  sync: 1,
+  storage: 1,
+  _other: 1,
 }
+currentLogLevelSettings = Object.assign(currentLogLevelSettings, envLogLevels);
 
-export function setLogLevels(logLevels: Partial<LogLevelSettings>): void {
-  Object.assign(logLevelSettings, logLevels)
+// global singleton to modify log levels...
+export function setLogLevels(newLogLevels: Partial<LogLevelSettings>): void {
+  currentLogLevelSettings = Object.assign(currentLogLevelSettings, newLogLevels);
+  // env settings always win, so apply them again
+  currentLogLevelSettings = Object.assign(currentLogLevelSettings, envLogLevels);
 }
 
 export default class Logger {
@@ -36,26 +79,30 @@ export default class Logger {
   }
   
   debug(...args:  any[]) {    
-    if (logLevelSettings[this._source] >= LogLevel.Debug) {
-      console.debug(args)
+    let allowedLevel = currentLogLevelSettings[this._source] ?? currentLogLevelSettings['_other'];
+    if (allowedLevel >= LogLevel.Debug) {
+      console.error(`[${this._source} debug]`, ...args)
     }
   }
   
   log(...args:  any[]) {
-    if (logLevelSettings[this._source] >= LogLevel.Log) {
-      console.log(args)
+    let allowedLevel = currentLogLevelSettings[this._source] ?? currentLogLevelSettings['_other'];
+    if (allowedLevel >= LogLevel.Log) {
+      console.error(`[${this._source} log]`, ...args)
     }
   }
   
   warn(...args:  any[]) {
-    if (logLevelSettings[this._source] >= LogLevel.Warn) {
-      console.warn(args)
+    let allowedLevel = currentLogLevelSettings[this._source] ?? currentLogLevelSettings['_other'];
+    if (allowedLevel >= LogLevel.Warn) {
+      console.error(`[${this._source} warn]`, ...args)
     }
   }
   
   error(...args:  any[]) {
-    if (logLevelSettings[this._source] >= LogLevel.Error) {
-      console.error(args)
+    let allowedLevel = currentLogLevelSettings[this._source] ?? currentLogLevelSettings['_other'];
+    if (allowedLevel >= LogLevel.Error) {
+      console.error(`[${this._source} error]`, ...args)
     }
   }
 }


### PR DESCRIPTION
I got carried away and made some changes on top of the logger PR:

- In `log.ts`, I rewrote the part that sets up the default log level settings.  Now the environment variable always wins if it's set, even if the code changes it manually using `setLoggerLevels()`.
- You can now use any string as a logger name, not just the predefined ones
- Default level is now 1 to include warnings

Smaller changes

- Logs are printed in a slightly different way now, like `[sync error] blah blah`
- In `index.ts` I exported the Logger class all the way out of Earthstar in case we want to use it from other repos like earthstar-pub
- Removed some unneeded imports here and there just for cleanup
- Found a couple of `console.error`s and converted them to the appropriate `logger.error`

If you are ok with this, feel free to merge this into your PR and then merge your PR into main.