### PR TITLE
Add async deleteMyData, IStorageAsync syncing TS fix.

### DIFF
--- a/src/extras.ts
+++ b/src/extras.ts
@@ -5,7 +5,7 @@ import {
     WriteResult,
 } from './util/types';
 import {
-    IStorage,
+    IStorage, IStorageAsync,
 } from './storage/storageTypes';
 import Logger from './util/log'
 
@@ -36,6 +36,43 @@ export let deleteMyDocuments = (storage: IStorage, keypair: AuthorKeypair) => {
             emptyDoc.deleteAfter = doc.deleteAfter + 1;
         }
         let result = storage.set(keypair, emptyDoc);
+        if (isErr(result)) {
+            storageLogger.error(`deleting ${doc.path}... error`);
+            numErrors += 1;
+        } else if (result === WriteResult.Ignored) {
+            storageLogger.log(`deleting ${doc.path}... ignored`);
+            numErrors += 1;
+        } else {
+            storageLogger.log(`deleting ${doc.path}... success`);
+        }
+    }
+    storageLogger.log(`done.  ${myDocs.length - numErrors} deleted; ${numErrors} had errors.`);
+    return {
+        numDeleted: myDocs.length,
+        numErrors,
+    };
+}
+
+export let deleteMyDocumentsAsync = async (storage: IStorageAsync, keypair: AuthorKeypair) => {
+    let myDocs = await storage.documents({
+        // include your old versions which are no longer the
+        // most recent version
+        author: keypair.address,
+        history: 'all',
+    });
+    storageLogger.log(`deleting ${myDocs.length} docs authored by ${keypair.address}...`);
+    let numErrors = 0;
+    for (let doc of myDocs) {
+        let emptyDoc: DocToSet = {
+            format: doc.format,
+            path: doc.path,
+            content: '',
+            timestamp: doc.timestamp + 1,
+        }
+        if (doc.deleteAfter !== null) {
+            emptyDoc.deleteAfter = doc.deleteAfter + 1;
+        }
+        let result = await storage.set(keypair, emptyDoc);
         if (isErr(result)) {
             storageLogger.error(`deleting ${doc.path}... error`);
             numErrors += 1;

--- a/src/sync/syncer2.ts
+++ b/src/sync/syncer2.ts
@@ -90,7 +90,7 @@ export class OnePubOneWorkspaceSyncer {
     unsubFromStorage: null | Thunk;
     state: SyncerState;
     onStateChange: Emitter<SyncerState>;
-    constructor(storage: IStorage, domain: string) {
+    constructor(storage: IStorage | IStorageAsync, domain: string) {
         this.storage = storage;
         this.domain = ensureTrailingSlash(domain);
         this.pullStream = null;


### PR DESCRIPTION
I missed a spot.

- Forgot to allow `IStorageAsync` in `OnePubOneWorkspaceSyncer`'s constructor
- Added an async version of `deleteMyData`.
  - The async version is pretty much a copy past with two await statements put in, but given what you said about breaking changes I thought it best to be on the safe side...