### PR TITLE
syncer2: catch error if Storage was closed while syncing was still happening

### DIFF
--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -22,7 +22,7 @@
 //
 // The environment variable wins over the numbers set by setLogLevels.
 
-type LogSource = 'sync' | 'storage' | string;
+type LogSource = 'sync' | 'syncer2' | 'storage' | string;
 
 enum LogLevel {
   // Level 0, error, is enabled by default
@@ -59,6 +59,7 @@ const envLogLevels: Partial<LogLevelSettings> =
 // set initial defaults to 1 (errors and warnings)
 let currentLogLevelSettings: LogLevelSettings = {
   sync: 1,
+  syncer2: 1,
   storage: 1,
   _other: 1,
 }


### PR DESCRIPTION
## What's the problem you solved?

This fixes a rare bug when using `react-earthstar`'s UI to remove a storage that's currently syncing.

When we have closed a storage, a few network callbacks can continue running briefly, causing them to attempt to do actions to the storage after the storage has been closed.  This causes the storage to throw a `StorageIsClosedError`.

(This is a hard to reproduce error but I think it happens sometimes.)

## What solution are you recommending?

Catch the `StorageIsClosedError` instead of letting it just crash the app.  The error will still be `console.error()`'d so we can see it happening.

Earthstar usually returns errors - it only throws them when it thinks someone is Using It Wrong, like using a Storage after closing it.  In this case it can't be avoided because of the timing of the network callbacks so it's ok to catch and ignore the error.

## Other notes

There are no unit tests for this syncing code. :(  It will probably all be replaced soon anyway.