### PR TITLE
type update: make list of validators be non-empty

### DIFF
--- a/src/storage/storageBase.ts
+++ b/src/storage/storageBase.ts
@@ -37,7 +37,7 @@ export abstract class StorageBase implements IStorage {
     _validatorMap: {[format: string]: IValidator};
     _discardInterval: any | null = null;
 
-    constructor(validators: IValidator[], workspace: WorkspaceAddress) {
+    constructor(validators: [IValidator, ...IValidator[]], workspace: WorkspaceAddress) {
 
         // when subclassing this class, you will need to call
         //    super(validators, workspace)
@@ -105,7 +105,7 @@ export abstract class StorageBase implements IStorage {
     }
 
     _assertNotClosed(): void {
-        if (this._isClosed) { throw new StorageIsClosedError(); }
+        if (this._isClosed) { throw new StorageIsClosedError(`A StorageBase instance for ${this.workspace} was used after being closed. `); }
     }
 
     abstract setConfig(key: string, content: string): void;

--- a/src/storage/storageLocalStorage.ts
+++ b/src/storage/storageLocalStorage.ts
@@ -40,7 +40,7 @@ export class StorageLocalStorage extends StorageMemory {
     _localStorageKeyDocs: string;
     _debouncedSaveQuick: () => void;
     _debouncedSaveSlow: () => void;
-    constructor(validators: IValidator[], workspace: WorkspaceAddress) {
+    constructor(validators: [IValidator, ...IValidator[]], workspace: WorkspaceAddress) {
         super(validators, workspace);
         logger.log('constructor for workspace ' + workspace);        
 

--- a/src/storage/storageMemory.ts
+++ b/src/storage/storageMemory.ts
@@ -26,7 +26,7 @@ export class StorageMemory extends StorageBase {
     _docs: Record<string, Record<string, Document>> = {};  // { path: { author: document }}
     _config: Record<string, string> = {};
 
-    constructor(validators: IValidator[], workspace: WorkspaceAddress) {
+    constructor(validators: [IValidator, ...IValidator[]], workspace: WorkspaceAddress) {
         super(validators, workspace);
         logger.log('constructor for workspace ' + workspace);        
     }

--- a/src/storage/storageSqlite.ts
+++ b/src/storage/storageSqlite.ts
@@ -53,19 +53,19 @@ const logger = new Logger('storage')
 interface StorageSqliteOptsCreate {
     mode: 'create'
     workspace: WorkspaceAddress,
-    validators: IValidator[],  // must provide at least one
+    validators: [IValidator, ...IValidator[]],  // must provide at least one
     filename: string,  // must not exist
 }
 interface StorageSqliteOptsOpen {
     mode: 'open'
     workspace: WorkspaceAddress | null,
-    validators: IValidator[],  // must provide at least one
+    validators: [IValidator, ...IValidator[]],  // must provide at least one
     filename: string,  // must exist
 }
 interface StorageSqliteOptsCreateOrOpen {
     mode: 'create-or-open'
     workspace: WorkspaceAddress,
-    validators: IValidator[],  // must provide at least one
+    validators: [IValidator, ...IValidator[]],  // must provide at least one
     filename: string,  // may or may not exist
 }
 export type StorageSqliteOpts =

--- a/src/test/benchmark.ts
+++ b/src/test/benchmark.ts
@@ -23,7 +23,7 @@ let randInt = (lo: number, hi: number) =>
 let WORKSPACE = '+gardenclub.xxxxxxxxxxxxxxxxxxxx';
 let WORKSPACE2 = '+another.xxxxxxxxxxxxxxxxxxxx';
 
-let VALIDATORS : IValidator[] = [ValidatorEs4];
+let VALIDATORS: [IValidator, ...IValidator[]] = [ValidatorEs4];
 let FORMAT : FormatName = VALIDATORS[0].format;
 
 let keypair1 = generateAuthorKeypair('test') as AuthorKeypair;

--- a/src/test/extras.test.ts
+++ b/src/test/extras.test.ts
@@ -25,7 +25,7 @@ import { deleteMyDocuments } from '../extras';
 
 let WORKSPACE = '+gardenclub.xxxxxxxxxxxxxxxxxxxx';
 
-let VALIDATORS : IValidator[] = [ValidatorEs4];
+let VALIDATORS: [IValidator, ...IValidator[]] = [ValidatorEs4];
 let FORMAT : FormatName = VALIDATORS[0].format;
 
 let keypair1 = generateAuthorKeypair('test') as AuthorKeypair;

--- a/src/test/storageAsync.test.ts
+++ b/src/test/storageAsync.test.ts
@@ -51,7 +51,7 @@ import { StorageToAsync } from '../storage/storageToAsync';
 let WORKSPACE = '+gardenclub.xxxxxxxxxxxxxxxxxxxx';
 let WORKSPACE2 = '+another.xxxxxxxxxxxxxxxxxxxx';
 
-let VALIDATORS : IValidator[] = [ValidatorEs4];
+let VALIDATORS : [IValidator, ...IValidator[]] = [ValidatorEs4];
 let FORMAT : FormatName = VALIDATORS[0].format;
 
 // tests assume these are in alphabetical order by author shortname
@@ -168,13 +168,13 @@ t.test(`StorageMemory: constructor success`, (t: any) => {
 });
 
 t.test(`StorageMemory: constructor errors`, (t: any) => {
-    t.throws(() => new StorageMemory([], WORKSPACE), 'throws when no validators are provided');
+    t.throws(() => new StorageMemory([] as any, WORKSPACE), 'throws when no validators are provided');
     t.throws(() => new StorageMemory(VALIDATORS, 'bad-workspace-address'), 'throws when workspace address is invalid');
     t.end();
 });
 
 t.test(`Async'd StorageMemory: constructor`, (t: any) => {
-    t.throws(() => new StorageToAsync(new StorageMemory([], WORKSPACE)), 'throws when no validators are provided');
+    t.throws(() => new StorageToAsync(new StorageMemory([] as any, WORKSPACE)), 'throws when no validators are provided');
     t.throws(() => new StorageToAsync(new StorageMemory(VALIDATORS, 'bad-workspace-address')), 'throws when workspace address is invalid');
     t.end();
 });
@@ -221,7 +221,7 @@ t.test(`StoreSqlite: opts: workspace and filename requirements`, (t: any) => {
         let storage = new StorageSqlite({
             mode: 'create',
             workspace: 'bad-workspace-address',
-            validators: [],
+            validators: [] as any,
             filename: ':memory:'
         });
         storage.close();

--- a/src/test/syncWithChannels.test.ts
+++ b/src/test/syncWithChannels.test.ts
@@ -46,7 +46,7 @@ import { StorageToAsync } from '../storage/storageToAsync';
 let WORKSPACE = '+gardenclub.xxxxxxxxxxxxxxxxxxxx';
 let WORKSPACE2 = '+another.xxxxxxxxxxxxxxxxxxxx';
 
-let VALIDATORS : IValidator[] = [ValidatorEs4];
+let VALIDATORS: [IValidator, ...IValidator[]] = [ValidatorEs4];
 let FORMAT : FormatName = VALIDATORS[0].format;
 
 // tests assume these are in alphabetical order by author shortname

--- a/src/test/syncer1.test.ts
+++ b/src/test/syncer1.test.ts
@@ -26,7 +26,7 @@ import { StorageToAsync } from '../storage/storageToAsync';
 // prepare for test scenarios
 
 let WORKSPACE = '+gardenclub.xxxxxxxxxxxxxxxxxxxx';
-let VALIDATORS : IValidator[] = [ValidatorEs4];
+let VALIDATORS: [IValidator, ...IValidator[]] = [ValidatorEs4];
 let FORMAT : FormatName = VALIDATORS[0].format;
 
 let keypair1 = generateAuthorKeypair('test') as AuthorKeypair;


### PR DESCRIPTION
## What's the problem you solved?

IStorage constructors take a list of validators.  That list needs to be non-empty, but before we just set its type as `IValidator[]` which allows empty arrays.

## What solution are you recommending?

Change the type to a tuple with a rest parameter:

```ts
[IValidator, ...IValidator[]]
```

Which is another way of saying "a non-empty array of `IValidator`s"

## Upsides

It will now be a type error to do `new StorageMemory([], '+gardening.ajfoiw')` with an empty validator array.

## Downsides

This type is more complex, will people understand it?  They may have to use this type in their application code; for example we had to update our test files that create IStorages.