### PR TITLE
Path templates!  for querying storages, and extracting pieces of paths

### DIFF
--- a/src/storage/queryHelpers.ts
+++ b/src/storage/queryHelpers.ts
@@ -273,6 +273,12 @@ export let _parseTemplate = (template: string): _parseTemplateReturn => {
         throw new ValidationError('weird curly brace mismatch, maybe }backwards{');
     }
 
+    // check for duplicate varNames
+    let varNamesSet = new Set(varNames);
+    if (varNamesSet.size !== varNames.length) {
+        throw new ValidationError('variable names may not be repeated');
+    }
+
     //--------------------------------------------------
     // MAKE GLOB VERSION
 

--- a/src/storage/queryHelpers.ts
+++ b/src/storage/queryHelpers.ts
@@ -30,18 +30,16 @@ export let escapeStringForRegex = (s: string): string => {
 };
 
 // same as string.matchAll(regex) which is only supported in node 12+
-// returns [
+// returns [{
 //    0: full match,
 //    1: group part of the match,
 //    index: number,
 //    input: string,
 //    groups: undefined
-// ]
-// TODO: bug: this loops forever when the regex does not have the 'g' flag
-// because it keeps returning the first match.
-let _matchAll = (re: RegExp, str: string): RegExpExecArray[] => {
+// }, {}, ...]
+export let _matchAll = (re: RegExp, str: string): RegExpExecArray[] => {
     if (re.flags.indexOf('g') === -1) {
-        throw new Error('this matchAll function only works on global regexes (with "g")');
+        throw new TypeError('matchAll requires a regex with the "g" flag set');
     }
     let matches: RegExpExecArray[] = [];
     let m: RegExpExecArray | null;
@@ -55,68 +53,22 @@ let _matchAll = (re: RegExp, str: string): RegExpExecArray[] => {
 // GLOBS
 
 /*
- * Helper for querying Earthstar docs using a glob-style query string.
+ *  A helper used by _globToQueryAndRegex -- see that function for details.
  *
- * Given a glob string, return:
- *    - an earthstar Query
- *    - and a regular expression (as a plain string, not a RegExp instance).
- *
- * Glob strings support '*' and '**' as wildcards.
- * '**' matches any sequence of characters at all.
- * '*' matches any sequence of characters except a forward slash --
- *  it does not span directories in the path.
- * You glob string may have multiple asterisks in various positions,
- * except they cannot be directly adjecent to each other (no '***' should
- * ever occur -- this will cause a ValidationError to be thrown).
- * 
- * To use this function, run the query yourself and apply the regex
- * as a filter to the paths of the resulting documents,
- * to get only the documents whose paths match the glob.
- * The regex will be null if it's not needed.
- * 
- * The returned query will use some subset of
- * the `path`, `pathStartsWith`, and `pathEndswith` properties,
- * and no other properties.
+ *  This function simply turns a glob string into a regex.
+ *  The other function calls this one, but sometimes discards the regex
+ *   if it's not needed because it can make a good enough Earthstar query.
  */
-// Example glob strings:
-//
-//     "/posts/*/*.json"    matches "/posts/sailing/12345.json"
-//
-//     "/posts/**.json"     matches "/posts/sailing/12345.json"
-//                              and "/posts/a/b/c/d/e/f/g/12345.json"
-//                              and "/posts/.json"
-//
-// To use it:
-// 
-//    let queryByGlob = (storage: IStorage, glob: string): Document[] => {
-//       let { query, pathRegex } = _parseGlob(glob);
-//  
-//       let docs = storage.documents(query);
-//       if (pathRegex != null) {
-//           let re = new RegExp(pathRegex);
-//           docs = docs.filter(doc => re.test(doc.path));
-//       }
-//       return docs;
-//    }
-//  
-//    let posts = queryByGlob(myStorage, '/posts/*.txt');
-export let _parseGlob = (glob: string): { query: Query, pathRegex: string | null } => {
+export let _globToRegex = (glob: string, forceEntireMatch: boolean = true): string => {
+    // Just turn a glob into a regex.
+    // '/hello/**/world/*.txt' --> '/hello/.*/world/[^/]*.txt'
+    // forceEntireMatch: make the regex match all way from beginning to end of string
+    // by surrounding it in ^ and $.
+
     // Three stars in a row are not allowed - throw
     if (glob.indexOf('***') !== -1) {
         throw new ValidationError('invalid glob query has three stars in a row: ' + glob);
     }
-
-    // If no stars at all, this is just a direct path query.  Easy.
-    if (glob.indexOf('*') === -1)  {
-        return { query: { path: glob }, pathRegex: null }
-    }
-
-    // Get the parts of the glob before the first star and after the last star.
-    // These will become our pathStartWith and pathEndsWith query paramters.
-    let globParts = glob.split('*');
-    let firstPart = globParts[0];
-    let lastPart = globParts[globParts.length - 1];
-
     // Convert the glob into a regex.
     // First replace * and ** with characters that are not allowed in earthstar strings,
     // and are also not regex control characters...
@@ -128,7 +80,77 @@ export let _parseGlob = (glob: string): { query: Query, pathRegex: string | null
     regex = replaceAll(regex, ';', '.*');  // any characters
     regex = replaceAll(regex, '#', '[^/]*');  // anything but slashes
     // Force the regex to match all way from beginning to end of string
-    regex = '^' + regex + '$';
+    if (forceEntireMatch) {
+        regex = '^' + regex + '$';
+    }
+    return regex;
+}
+
+/*
+ * Helper for querying Earthstar docs using a glob-style query string.
+ *
+ * Given a glob string, return:
+ *    - an earthstar Query
+ *    - and a regular expression (as a plain string, not a RegExp instance).
+ *
+ * Glob strings support '*' and '**' as wildcards.
+ * '**' matches any sequence of characters at all including slashes.
+ * '*' matches any sequence of characters except a forward slash --
+ *  it does not span directories in the path.
+ * Your glob string may have multiple asterisks in various positions,
+ *  except they cannot be directly adjecent to each other (no '***' should
+ *  ever occur -- this will cause a ValidationError to be thrown).
+ * 
+ * Note that no other wildcards are supported, unlike Bash globs.
+ * 
+ * To use this function, run the query yourself and apply the regex
+ * as a filter to the paths of the resulting documents,
+ *  to get only the documents whose paths match the glob.
+ * The regex will be null if it's not needed (if the query is
+ *  strong enough to get the job done by itself).
+ * 
+ * The returned query will use some subset of
+ *  the `path`, `pathStartsWith`, and `pathEndswith` properties,
+ *  and no other properties.
+ *
+ * Example glob strings:
+ *
+ *     "/posts/*ing/*.json" matches "/posts/sailing/12345.json"
+ *
+ *     "/posts/**.json"     matches "/posts/sailing/12345.json"
+ *                              and "/posts/a/b/c/d/e/f/g/12345.json"
+ *                              and "/posts/.json"
+ * 
+ *     "**"                 matches every possible path
+ *
+ * To use it:
+ * 
+ *    let queryByGlob = (storage: IStorage, glob: string): Document[] => {
+ *       let { query, regex } = _globToQueryAndRegex(glob);
+ *  
+ *       let docs = storage.documents(query);
+ *       if (regex != null) {
+ *           let re = new RegExp(regex);
+ *           docs = docs.filter(doc => re.test(doc.path));
+ *       }
+ *       return docs;
+ *    }
+ *  
+ *    let posts = queryByGlob(myStorage, '/posts/*.txt');
+ */
+export let _globToQueryAndRegex = (glob: string): { query: Query, regex: string | null } => {
+    // Turn a glob into a query and an optional regex, if a regex is needed.
+
+    // If no stars at all, this is just a direct path query.
+    if (glob.indexOf('*') === -1)  {
+        return { query: { path: glob }, regex: null }
+    }
+
+    // Get the parts of the glob before the first star and after the last star.
+    // These will become our pathStartWith and pathEndsWith query paramters.
+    let globParts = glob.split('*');
+    let firstPart = globParts[0];
+    let lastPart = globParts[globParts.length - 1];
 
     // Put startsWith and endsWith into the query if needed
     let query: Query = {};
@@ -137,19 +159,26 @@ export let _parseGlob = (glob: string): { query: Query, pathRegex: string | null
 
     // Special case for "**foo" or "foo**" -- no regex is needed for these,
     // we can rely completely on pathStartsWith or pathEndsWith
-    let pathRegex: string | null = regex;
+    let regex: string | null = '?';
     if (globParts.length === 3) {
         let [a, b, c] = globParts;
-        if (a === '' && b === '') { pathRegex = null }
-        if (b === '' && c === '') { pathRegex = null }
+        if (a === '' && b === '') { regex = null }
+        if (b === '' && c === '') { regex = null }
+    }
+    // special case did not apply, calculate the regex
+    if (regex === '?') {
+        regex = _globToRegex(glob);
     }
 
-    return { query, pathRegex };
+    return { query, regex };
 }
+
+//================================================================================
+// GLOB: USER-FACING API CALLS
 
 /*
  * Find documents whose path matches the glob string.
- * See documentation for _parseGlob for details on glob strings.
+ * See documentation for _globToQueryAndRegex for details on glob strings.
  *
  * This is a synchronous function and `storage` must be synchronous (an `IStorage`).
  * 
@@ -162,12 +191,12 @@ export let _parseGlob = (glob: string): { query: Query, pathRegex: string | null
  * intend to override the glob's query.
  */
 export let queryByGlobSync = (storage: IStorage, glob: string, moreQueryOptions: Query = {}): Document[] => {
-    let { query, pathRegex } = _parseGlob(glob);
+    let { query, regex } = _globToQueryAndRegex(glob);
     query = { ...query, ...moreQueryOptions };
  
     let docs = storage.documents(query);
-    if (pathRegex != null) {
-        let re = new RegExp(pathRegex);
+    if (regex != null) {
+        let re = new RegExp(regex);
         docs = docs.filter(doc => re.test(doc.path));
     }
     return docs;
@@ -175,7 +204,7 @@ export let queryByGlobSync = (storage: IStorage, glob: string, moreQueryOptions:
 
 /*
  * Find documents whose path matches the glob string.
- * See documentation for _parseGlob for details on glob strings
+ * See documentation for _globToQueryAndRegex for details on glob strings.
  * 
  * This is an async function and `storage` can be either an async or sync storage
  * (`IStorage` or `IStorageAsync`).
@@ -189,12 +218,12 @@ export let queryByGlobSync = (storage: IStorage, glob: string, moreQueryOptions:
  * intend to override the glob's query.
  */
 export let queryByGlobAsync = async (storage: IStorage | IStorageAsync, glob: string, moreQueryOptions: Query = {}): Promise<Document[]> => {
-    let { query, pathRegex } = _parseGlob(glob);
+    let { query, regex } = _globToQueryAndRegex(glob);
     query = { ...query, ...moreQueryOptions };
  
     let docs = await storage.documents(query);
-    if (pathRegex != null) {
-        let re = new RegExp(pathRegex);
+    if (regex != null) {
+        let re = new RegExp(regex);
         docs = docs.filter(doc => re.test(doc.path));
     }
     return docs;
@@ -224,31 +253,45 @@ while ((m = variableRe.exec(template)) !== null) {
 interface _parseTemplateReturn {
     varNames: string[],  // the names of the variables, in the order they occur, without brackets
     glob: string,  // the template with all the variables replaced by '*'
-    pathMatcherRe: string,  // a regex string that will match paths and do named captures of the variables
+    namedCaptureRegex: string,  // a regex string that will match paths and do named captures of the variables
 }
+/*
+ *  This is a low-level helper for the template matching code; probably don't use it directly.
+ *  
+ *  Given a template, parse it and return:
+ *  - a list of variable names
+ *  - a glob for searching Earthstar using queryByGlob()
+ *  - a regular expression with named capture groups which can extract the
+ *     values of the variables from a path.
+ *  
+ *  A variable in the template is any alphanumeric chars or underscores, in curly braces
+ *   like {example} or {__EXAMPLE__} or {example_1}, starting with a non-number.
+ * 
+ *  Templates can also contain * and ** according to the glob rules.
+ *   Those wildcards are not counted as variables but are allowed to expand during the
+ *   regex phase.
+ *  
+ *  Rules for templates:
+ *  - Variable names must only contain upper and lower letters, numbers, and underscore.
+ *  - They cannot start with a number.
+ *  - They cannot be empty {}.
+ *  - Two variables cannot be directly touching {like}{this}.
+ *  - A variable cannot be directly touching a star {likeThis}* or *{likeThis}.
+ * 
+ *  If variable names don't match these rules, a ValidationError will be thrown.
+ * 
+ */
 export let _parseTemplate = (template: string): _parseTemplateReturn => {
-    // This is a low-level helper for the template matching code; probably don't use it directly.
-    //
-    // Given a template, parse it and return
-    // - a list of variable names
-    // - a regular expression that can be used to match against a path, with named capture groups
-    //    that are named the same as the variables, to extract the variables from the path
-    //
-    // A variable in the template is any alphanumeric chars or underscores, in curly braces
-    // like {example} or {__EXAMPLE__} or {example_1}
-    //
-    // Rules for templates
-    //   Variable names must only contain upper and lower letters, numbers, and underscore.
-    //   They cannot start with a number.
-    //   They cannot be empty {}.
-    //   Two variables cannot be consecutive and touching {like}{this}.
-    // If variable names don't match these rules, a ValidationError will be thrown.
 
     //--------------------------------------------------------------------------------
     // VALIDATE TEMPLATE and extract variable names
 
     if (template.indexOf('}{') !== -1) { 
         throw new ValidationError('template is not allowed to have to adjacent variables {like}{this}');
+    }
+
+    if (template.indexOf('*{') !== -1 || template.indexOf('}*') !== -1) { 
+        throw new ValidationError('template cannot have a star touching a variable *{likeThis}');
     }
 
     let numLBrackets = countChars(template, '{');
@@ -288,9 +331,13 @@ export let _parseTemplate = (template: string): _parseTemplateReturn => {
     //--------------------------------------------------------------------------------
     // MAKE PATH REGEX
 
+    // normally we would put each path part through escapeStringForRegex()...
+    // but we want to allow stars to be mixed in with template variables,
+    // so instead we use _globToRegex() with false to prevent it from
+    // wrapping each part in ^ and $.
     let parts: string[] = [];
     if (varMatches.length === 0) {
-        parts.push(escapeStringForRegex(template));
+        parts.push(_globToRegex(template, false));
     }
     for (let ii = 0; ii < varMatches.length; ii++) {
         let bracketMatch = varMatches[ii];
@@ -300,7 +347,7 @@ export let _parseTemplate = (template: string): _parseTemplateReturn => {
 
         if (ii === 0) {
             let begin = template.slice(0, matchStart);
-            parts.push(escapeStringForRegex(begin));
+            parts.push(_globToRegex(begin, false));
         }
 
         // make a regex to capture the actual value of this variable in a path
@@ -310,30 +357,33 @@ export let _parseTemplate = (template: string): _parseTemplateReturn => {
         if (ii <= varMatches.length - 2) {
             let nextMatch = varMatches[ii+1];
             let between = template.slice(matchEnd, nextMatch.index);
-            parts.push(escapeStringForRegex(between));
+            parts.push(_globToRegex(between, false));
         } else {
             let end = template.slice(matchEnd);
-            parts.push(escapeStringForRegex(end));
+            parts.push(_globToRegex(end, false));
         }
     }
-    let pathMatcherRe = '^' + parts.join('') + '$';
+    let namedCaptureRegex = '^' + parts.join('') + '$';
 
     return {
         varNames,
         glob,
-        pathMatcherRe,
+        namedCaptureRegex,
     };
 }
 
-// This is a low-level helper for the template matching code; probably don't use it directly.
-//
-// Given a pathMatcherRe (made from a template using _parseTemplate),
-// check if a given Earthstar patch matches it.
-// If it does not match, return null.
-// If it does match, return an object with the variables from the template.
-// A template can have zero variables; in this case we return {} on match and null on no match.
-export let _extractTemplateValuesUsingRe = (pathMatcherRe: string, path: string): Record<string, string> | null => {
-    const matches2 = path.match(new RegExp(pathMatcherRe));
+/*
+ *  This is a low-level helper for the template matching code; probably don't use it directly.
+ *  See extractTemplateVariablesFromPath for more details.
+ *
+ *  Given a namedCaptureRegex (made from a template using _parseTemplate),
+ *   check if a given Earthstar path matches it.
+ *  If it does match, return an object with the variables from the template.
+ *  If it does not match, return null.
+ *  A template can have zero variables; in this case we return {} on match and null on no match.
+ */
+export let _extractTemplateValuesUsingRe = (namedCaptureRegex: string, path: string): Record<string, string> | null => {
+    const matches2 = path.match(new RegExp(namedCaptureRegex));
     if (matches2 === null) { return null; }
     return { ...matches2.groups };
 }
@@ -372,17 +422,23 @@ export let _extractTemplateValuesUsingRe = (pathMatcherRe: string, path: string)
  * 
  * Variable names must only contain upper or lower case letters, numbers, or underscores.
  * They must not start with a number.
+ * 
+ * Template strings can also contain * and **; these are not counted as variables but do
+ *  help determine if the overall path matches the template.  See the glob functions
+ *  for details on how those wildcards work.
  */
 export let extractTemplateVariablesFromPath = (template: string, path: string): Record<string, string> | null => {
-    // if template has no variables, just compare it directly with the path
-    // and avoid all this regex nonsense
+    // if template has no variables, just compare it directly with the path and avoid all this regex nonsense
     if (template.indexOf('{') === -1 && template.indexOf('}') === -1) {
         return (template === path ? {} : null);
     }
     // this also returns { varnames, glob } but we don't use them here
-    let { pathMatcherRe } = _parseTemplate(template);
-    return _extractTemplateValuesUsingRe(pathMatcherRe, path);
+    let { namedCaptureRegex } = _parseTemplate(template);
+    return _extractTemplateValuesUsingRe(namedCaptureRegex, path);
 }
+
+//================================================================================
+// TEMPLATE: USER-FACING API CALLS
 
 /*
  * Given a template string like "/posts/{postId}.json",
@@ -395,7 +451,7 @@ export let extractTemplateVariablesFromPath = (template: string, path: string): 
  * You can get the variables out of your document paths like this:
  * 
  *      let template = '/posts/{postId}.json';
- *      let docs = queryByTemplateSync(myStorgae, template);
+ *      let docs = queryByTemplateSync(myStorage, template);
  *      for (let doc of docs) {
  *          // vars will be like { postId: 'abc' }
  *          let vars = extractTemplateVariablesFromPath(template, doc.path);
@@ -403,12 +459,12 @@ export let extractTemplateVariablesFromPath = (template: string, path: string): 
  */
 export let queryByTemplateSync = (storage: IStorage, template: string, moreQueryOptions: Query = {}): Document[] => {
     let { glob } = _parseTemplate(template);
-    let { query, pathRegex } = _parseGlob(glob);
+    let { query, regex } = _globToQueryAndRegex(glob);
     query = { ...query, ...moreQueryOptions };
 
     let docs = storage.documents(query);
-    if (pathRegex != null) {
-        let re = new RegExp(pathRegex);
+    if (regex != null) {
+        let re = new RegExp(regex);
         docs = docs.filter(doc => re.test(doc.path));
     }
     return docs;
@@ -425,7 +481,7 @@ export let queryByTemplateSync = (storage: IStorage, template: string, moreQuery
  * You can get the variables out of your document paths like this:
  * 
  *      let template = '/posts/{postId}.json';
- *      let docs = await queryByTemplateAsync(myStorgae, template);
+ *      let docs = await queryByTemplateAsync(myStorage, template);
  *      for (let doc of docs) {
  *          // vars will be like { postId: 'abc' }
  *          let vars = extractTemplateVariablesFromPath(template, doc.path);
@@ -433,12 +489,12 @@ export let queryByTemplateSync = (storage: IStorage, template: string, moreQuery
  */
 export let queryByTemplateAsync = async (storage: IStorage | IStorageAsync, template: string, moreQueryOptions: Query = {}): Promise<Document[]> => {
     let { glob } = _parseTemplate(template);
-    let { query, pathRegex } = _parseGlob(glob);
+    let { query, regex } = _globToQueryAndRegex(glob);
     query = { ...query, ...moreQueryOptions };
  
     let docs = await storage.documents(query);
-    if (pathRegex != null) {
-        let re = new RegExp(pathRegex);
+    if (regex != null) {
+        let re = new RegExp(regex);
         docs = docs.filter(doc => re.test(doc.path));
     }
     return docs;

--- a/src/storage/queryHelpers.ts
+++ b/src/storage/queryHelpers.ts
@@ -9,6 +9,9 @@ import {
     Query
 } from './query';
 
+//================================================================================
+// HELPERS
+
 /*
  * Escape a string so it's safe to use in a regular expression.
  * (Put a backslash in front of each special regex character
@@ -20,11 +23,41 @@ export let escapeStringForRegex = (s: string): string => {
     //    ^ $ \ . * + ? ( ) [ ] { } |
 
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
-}
+};
 
 let replaceAll = (str: string, from: string, to: string): string => {
     return str.split(from).join(to);
+};
+
+// how many times does the character occur in the string?
+let countChars = (str: string, char: string) => {
+    return str.split(char).length - 1;
+};
+
+// same as string.matchAll(regex) which is only supported in node 12+
+// returns [
+//    0: full match,
+//    1: group part of the match,
+//    index: number,
+//    input: string,
+//    groups: undefined
+// ]
+// TODO: bug: this loops forever when the regex does not have the 'g' flag
+// because it keeps returning the first match.
+let matchAll = (re: RegExp, str: string): RegExpExecArray[] => {
+    if (re.flags.indexOf('g') === -1) {
+        throw new Error('this matchAll function only works on global regexes (with "g")');
+    }
+    let matches: RegExpExecArray[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(str)) !== null) {
+        matches.push(m)
+    }
+    return matches;
 }
+
+//================================================================================
+// GLOBS
 
 /*
  * Helper for querying Earthstar docs using a glob-style query string.
@@ -174,4 +207,173 @@ export let queryByGlobAsync = async (storage: IStorage | IStorageAsync, glob: st
         docs = docs.filter(doc => re.test(doc.path));
     }
     return docs;
+}
+
+//==========================================================================================
+// TEMPLATES
+
+/*
+// HOW TO USE REGEXES
+
+console.log('-------------- matchAll homebrew');
+let varMatches = matchAll(variableRe, template);
+console.log(varMatches.map(match => match[1]));
+
+console.log('-------------- match');
+let matches = template.match(variableRe);
+console.log(matches);
+
+console.log('-------------- exec');
+let m;
+while ((m = variableRe.exec(template)) !== null) {
+    console.log(m);
+}
+*/
+
+interface TemplateToPathMatcherReturn {
+    varNames: string[],
+    pathMatcherRe: string,
+}
+export let _templateToPathMatcherRegex = (template: string): TemplateToPathMatcherReturn => {
+    // This is a low-level helper for the template matching code; don't use it directly.
+    //
+    // Given a template, parse it and return
+    // - a list of variable names
+    // - a regular expression that can be used to match against a path, with named capture groups
+    //    that are named the same as the variables, to extract the variables from the path
+    //
+    // A variable in the template is any alphanumeric chars or underscores, in curly braces
+    // like {example} or {__EXAMPLE__} or {example_1}
+    //
+    // Rules for templates
+    //   Variable names must only contain upper and lower letters, numbers, and underscore.
+    //   They cannot start with a number.
+    //   They cannot be empty {}.
+    //   Two variables cannot be consecutive and touching {like}{this}.
+    // If variable names don't match these rules, a ValidationError will be thrown.
+
+    //--------------------------------------------------------------------------------
+    // VALIDATE TEMPLATE and extract variable names
+
+    if (template.indexOf('}{') !== -1) { 
+        throw new ValidationError('template is not allowed to have to adjacent variables {like}{this}');
+    }
+
+    let numLBrackets = countChars(template, '{');
+    let numRBrackets = countChars(template, '}');
+    if (numLBrackets !== numRBrackets) {
+        throw new ValidationError('unbalanced curly braces');
+    }
+
+    let bracketVarRe = /\{(.*?)\}/g  // match and capture anything in curly braces, lazily, to get smallest matches
+    let validVarName = /^[a-zA-Z_][a-zA-Z0-9_]*$/  // requirement for variable names: (alpha alphanum*)
+
+    let varMatches = matchAll(bracketVarRe, template);
+    // capture anything in braces...
+    let varNames = varMatches.map(match => match[1]);
+    // ...then check if it's a valid variable name, and throw errors if it's not
+    for (let varName of varNames) {
+        if (!validVarName.test(varName)) {
+            throw new ValidationError('variable name in template is not valid.  can only contain alphanumeric and underscore, and not start with number');
+        }
+    }
+    if (numLBrackets !== varNames.length || numRBrackets !== varNames.length) {
+        throw new ValidationError('weird curly brace mismatch, maybe }backwards{');
+    }
+
+    //--------------------------------------------------------------------------------
+    // MAKE PATH REGEX
+
+    let parts: string[] = [];
+    if (varMatches.length === 0) {
+        parts.push(escapeStringForRegex(template));
+    }
+    for (let ii = 0; ii < varMatches.length; ii++) {
+        let bracketMatch = varMatches[ii];
+        let varName = bracketMatch[1];
+        let matchStart = bracketMatch.index;
+        let matchEnd = bracketMatch.index + bracketMatch[0].length;
+
+        if (ii === 0) {
+            let begin = template.slice(0, matchStart);
+            parts.push(escapeStringForRegex(begin));
+        }
+
+        // make a regex to capture the actual value of this variable in a path
+        let reForThisVariable = '(?<' + varName + '>[^/]+)';
+        parts.push(reForThisVariable);
+        
+        if (ii <= varMatches.length - 2) {
+            let nextMatch = varMatches[ii+1];
+            let between = template.slice(matchEnd, nextMatch.index);
+            parts.push(escapeStringForRegex(between));
+        } else {
+            let end = template.slice(matchEnd);
+            parts.push(escapeStringForRegex(end));
+        }
+    }
+    let pathMatcherRe = '^' + parts.join('') + '$';
+
+    return {
+        varNames: varNames,
+        pathMatcherRe: pathMatcherRe,
+    };
+}
+
+// This is a low-level helper for the template matching code; don't use it directly.
+//
+// Given a pathMatcherRe (made from a template using templateToMathMatcherRegex),
+// check if a given Earthstar patch matches it.
+// If it does not match, return null.
+// If it does match, return an object with the variables from the template.
+// A template can have zero variables; in this case we return {} on match and null on no match.
+export let _matchRegexAndPath = (pathMatcherRe: string, path: string): Record<string, string> | null => {
+    const matches2 = path.match(new RegExp(pathMatcherRe));
+    if (matches2 === null) { return null; }
+    return { ...matches2.groups };
+}
+
+/*
+ * Compare template strings to actual paths and extract the variables from the paths.
+ * 
+ * Given a template like '/posts/{postId}.json', check if a given Earthstar patch matches it.
+ * If it DOES match, return an object with the variables from the template, like { postId: "abc" }.
+ * If it does NOT match, return null.
+ * 
+ * General examples:
+ *      // one variable
+ *      matchTemplateAndPath('/posts/{postId}.json', '/posts/abc.json') --> { postId: 'abc' }
+ *      matchTemplateAndPath('/posts/{postId}.json', '/nope') --> null
+ * 
+ *      // multiple variables
+ *      matchTemplateAndPath('/posts/{category}/{postId}.json', '/posts/gardening/abc.json')
+ *          --> { category: 'gardening', postId: 'abc' }
+ * 
+ *      // no variables
+ *      matchTemplateAndPath('/hello.txt', '/hello.txt') --> { }
+ *      matchTemplateAndPath('/hello.txt', '/nope') --> null
+ * 
+ * A template can have zero variables; in this case we return {} if the template is identical
+ * to the path, or null if it's different.
+ * 
+ * A path must have at least one character to fill the variable with.
+ *   Example: template: '/posts/{postId}.json'
+ *                path: '/posts/.json' will not match because the variable would be empty.
+ * 
+ * Variables can't span across path segments (they won't match '/' characters)
+ *   Example: template: '/posts/{postId}.json'
+ *                path: '/posts/123/456.json' will not match because there's a '/' in the way.
+ * 
+ * Variable names must only contain upper or lower case letters, numbers, or underscores.
+ * They must not start with a number.
+ */
+export let matchTemplateAndPath = (template: string, path: string): Record<string, string> | null => {
+    // if template has no variables, just compare it directly with the path
+    // and avoid all this regex nonsense
+    if (template.indexOf('{') === -1 && template.indexOf('}') === -1) {
+        return (template === path ? {} : null);
+    }
+    // this also returns { varnames } but we don't use it here
+    let { pathMatcherRe } = _templateToPathMatcherRegex(template);
+    return _matchRegexAndPath(pathMatcherRe, path);
 }

--- a/src/test/helpers.test.ts
+++ b/src/test/helpers.test.ts
@@ -2,9 +2,11 @@ import t = require('tap');
 //t.runOnly = true;
 
 import {
+    countChars,
     isPlainObject,
     objWithoutUndefined,
     range,
+    replaceAll,
     sorted,
     stringMult,
     uniq,
@@ -79,6 +81,43 @@ t.test('objWithoutUndefined', (t: any) => {
     for (let [inpt, goal] of cases) {
         let result = objWithoutUndefined(inpt);
         t.same(result, goal);
+    }
+    t.done();
+});
+
+t.test('replaceAll', (t: any) => {
+    let cases: [string, string, string, string][] = [
+        // input, desired output
+        ['hello', 'l', 'w', 'hewwo'],
+        ['hello', 'l', 'ww', 'hewwwwo'],
+        ['hello', 'l', '', 'heo'],
+        ['a-a-a-b-', 'a-', '', 'b-'],
+        ['a-a-a-b-', 'b-', '', 'a-a-a-'],
+        ['banana', 'ana', 'x', 'bxna'],
+    ]
+    for (let [str, from, to, goal] of cases) {
+        let result = replaceAll(str, from, to);
+        t.same(result, goal);
+    }
+    t.done();
+});
+
+t.test('countChars', (t: any) => {
+    let cases: [string, string, number | false][] = [
+        // input, desired output or false if it should throw
+        ['aaa', 'a', 3],
+        ['', 'a', 0],
+        ['___a_a_____a_aaa', 'a', 6],
+        ['aaa', 'not-one-char', false],
+        ['aaa', '', false],
+    ]
+    for (let [str, char, goal] of cases) {
+        if (goal === false) {
+            t.throws(() => countChars(str, char));
+        } else {
+            let result = countChars(str, char);
+            t.same(result, goal);
+        }
     }
     t.done();
 });

--- a/src/test/queryHelpers.test.ts
+++ b/src/test/queryHelpers.test.ts
@@ -523,20 +523,21 @@ t.test('_parseTemplate', (t: any) => {
             },
         },
         {
-            template: '/twovars/{category}/{postId}.{ext}',
-            glob: '/twovars/*/*.*',
+            template: '/threevars/{category}/{postId}.{ext}',
+            glob: '/threevars/*/*.*',
             varNames: ['category', 'postId', 'ext'],
             pathsAndExtractedVars: {
-                '/twovars/gardening/123.json': { category: 'gardening', postId: '123', ext: 'json' },
+                '/threevars/gardening/123.json': { category: 'gardening', postId: '123', ext: 'json' },
                 // (note that this test example is not a valid earthstar path because it contains '//')
-                '/twovars//123.json': { category: '', postId: '123', ext: 'json' },
-                '/twovars/gardening': null,
+                '/threevars//123.json': { category: '', postId: '123', ext: 'json' },
+                '/threevars/gardening': null,
                 '/nope': null,
                 '': null,
             },
         },
         //--------------------------------------------------
         // invalid: should throw a Validation Error
+        { invalid: true, template: '/same/var/repeated/twice/{a}/{a}' },
         { invalid: true, template: '/two/consecutive/vars/{a}{b}/in/a/row' },
         { invalid: true, template: '/var/starting/with/number/{0abc}' },
         { invalid: true, template: '/var/with/no/name/{}' },
@@ -558,27 +559,29 @@ t.test('_parseTemplate', (t: any) => {
         if ('invalid' in vector) {
             try {
                 t.true(true, `---  ${vector.template}  ---`);
+                t.true(true, `_parseTemplate...`);
                 // this should throw a ValidationError
                 let _thisShouldThrow = _parseTemplate(vector.template);
                 t.true(false, `${vector.template} - should throw a ValidationError but did not (_template...)`);
             } catch (err) {
                 if (err instanceof ValidationError) {
-                    t.true(true, `should throw a ValidationError`);// (message was: ${err.message})`);
+                    t.true(true, `${vector.template} - should throw a ValidationError`);// (message was: ${err.message})`);
                 } else {
-                    t.true(false, 'should throw a ValidationError but instead threw a ' + err.name);
+                    t.true(false, `${vector.template} - should throw a ValidationError but instead threw a ${err.name}`);
                     console.error(err);
                 }
             }
 
             try {
+                t.true(true, `extractTemplateVariablesFromPath`);
                 // this should also throw a ValidationError
                 let _thisShouldThrow = extractTemplateVariablesFromPath(vector.template, '/hello');
                 t.true(false, `${vector.template} - should throw a ValidationError but did not (matchTemplate...)`);
             } catch (err) {
                 if (err instanceof ValidationError) {
-                    t.true(true, `should throw a ValidationError`);// (message was: ${err.message})`);
+                    t.true(true, `${vector.template} - should throw a ValidationError`);// (message was: ${err.message})`);
                 } else {
-                    t.true(false, 'should throw a ValidationError but instead threw a ' + err.name);
+                    t.true(false, `${vector.template} - should throw a ValidationError but instead threw a ${err.name}`);
                     console.error(err);
                 }
             }
@@ -691,11 +694,6 @@ t.test('queryByTemplateSync', (t: any) => {
         let actualPaths = docs.map(doc => doc.path);
         actualPaths.sort();
         expectedPaths.sort();
-
-        console.log(template);
-        console.log(expectedPaths);
-        console.log(actualPaths);
-
         let note = vector.note ? ` (${vector.note})` : '';
         t.same(actualPaths, expectedPaths, `template: ${template} should match ${expectedPaths.length} paths.${note}`);
     }
@@ -721,11 +719,6 @@ t.test('queryByTemplateAsyncSync', async (t) => {
         let actualPaths = docs.map(doc => doc.path);
         actualPaths.sort();
         expectedPaths.sort();
-
-        console.log(template);
-        console.log(expectedPaths);
-        console.log(actualPaths);
-
         let note = vector.note ? ` (${vector.note})` : '';
         t.same(actualPaths, expectedPaths, `template: ${template} should match ${expectedPaths.length} paths.${note}`);
     }

--- a/src/test/queryHelpers.test.ts
+++ b/src/test/queryHelpers.test.ts
@@ -406,6 +406,7 @@ t.test('matchTemplateAndPath', (t: any) => {
     type StringToString = Record<string, string>;
     interface ValidVector {
         template: string,
+        glob?: string,
         varNames: string[],
         pathsAndExtractedVars: Record<string, StringToString | null>,
     }
@@ -417,6 +418,7 @@ t.test('matchTemplateAndPath', (t: any) => {
     let vectors: Vector[] = [
         {
             template: '',
+            glob: '',
             varNames: [],
             pathsAndExtractedVars: {
                 '/novars.json': null,
@@ -426,6 +428,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/novars.json',
+            glob: '/novars.json',
             varNames: [],
             pathsAndExtractedVars: {
                 '/novars.json': {},
@@ -435,6 +438,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/onevar/{_underscores_CAPS_and_digits_12345}.json',
+            glob: '/onevar/*.json',
             varNames: ['_underscores_CAPS_and_digits_12345'],
             pathsAndExtractedVars: {
                 '/onevar/123.json': { '_underscores_CAPS_and_digits_12345': '123' },
@@ -442,6 +446,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/onevar/{___}.json',
+            glob: '/onevar/*.json',
             varNames: ['___'],
             pathsAndExtractedVars: {
                 '/onevar/123.json': { '___': '123' },
@@ -449,6 +454,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/onevar/{_0}.json',
+            glob: '/onevar/*.json',
             varNames: ['_0'],
             pathsAndExtractedVars: {
                 '/onevar/123.json': { '_0': '123' },
@@ -456,6 +462,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/onevar/{postId}.json',
+            glob: '/onevar/*.json',
             varNames: ['postId'],
             pathsAndExtractedVars: {
                 '/onevar/123.json': { postId: '123' },
@@ -467,6 +474,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/onevar/post:{postId}.json',
+            glob: '/onevar/post:*.json',
             varNames: ['postId'],
             pathsAndExtractedVars: {
                 '/onevar/post:123.json': { postId: '123' },
@@ -474,6 +482,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/onevar/thisIsPost{postId}yesThatOne.json',
+            glob: '/onevar/thisIsPost*yesThatOne.json',
             varNames: ['postId'],
             pathsAndExtractedVars: {
                 '/onevar/thisIsPost123yesThatOne.json': { postId: '123' },
@@ -481,6 +490,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/twovars/{category}/{postId}.json',
+            glob: '/twovars/*/*.json',
             varNames: ['category', 'postId'],
             pathsAndExtractedVars: {
                 '/twovars/gardening/123.json': { category: 'gardening', postId: '123' },
@@ -493,6 +503,7 @@ t.test('matchTemplateAndPath', (t: any) => {
         },
         {
             template: '/twovars/{category}/{postId}.{ext}',
+            glob: '/twovars/*/*.*',
             varNames: ['category', 'postId', 'ext'],
             pathsAndExtractedVars: {
                 '/twovars/gardening/123.json': { category: 'gardening', postId: '123', ext: 'json' },
@@ -553,8 +564,11 @@ t.test('matchTemplateAndPath', (t: any) => {
             // should be valid
 
             t.true(true, `---  ${vector.template}  ---`);
-            let { varNames, pathMatcherRe } = _templateToPathMatcherRegex(vector.template);
+            let { varNames, glob, pathMatcherRe } = _templateToPathMatcherRegex(vector.template);
             t.same(varNames, vector.varNames, 'varNames should match');
+            if (vector.glob !== undefined) {
+                t.same(glob, vector.glob, 'glob should match');
+            }
 
             for (let [path, expectedVars] of Object.entries(vector.pathsAndExtractedVars)) {
                 let actualVars = _matchRegexAndPath(pathMatcherRe, path);

--- a/src/test/queryHelpers.test.ts
+++ b/src/test/queryHelpers.test.ts
@@ -15,9 +15,9 @@ import { StorageToAsync } from '../storage/storageToAsync';
 import { generateAuthorKeypair } from '../crypto/crypto';
 
 import {
-    _extractTemplateValuesUsingRe,
-    _globToQueryAndRegex,
-    _parseTemplate,
+    extractTemplateVariablesFromPathUsingRegex,
+    globToQueryAndRegex,
+    parseTemplate,
     escapeStringForRegex,
     extractTemplateVariablesFromPath,
     queryByGlobAsync,
@@ -85,7 +85,7 @@ t.test('_matchAll', (t: any) => {
 
 // TODO: test _globToRegex (though it's used vicariously through _globToQueryAndRegex)
 
-t.test('_globToQueryAndRegex', async (t) => {
+t.test('globToQueryAndRegex', async (t) => {
     interface Vector {
         note?: string,
         glob: string,
@@ -262,7 +262,7 @@ t.test('_globToQueryAndRegex', async (t) => {
     for (let vector of vectors) {
         let { glob, esQuery, regex, matchingPaths, nonMatchingPaths } = vector;
 
-        let result = _globToQueryAndRegex(glob);
+        let result = globToQueryAndRegex(glob);
 
         t.same(true, true, `--- ${vector.glob}   ${vector.note ?? ''} ---`);
         t.same(result.query, esQuery, 'query is as expected: ' + glob);
@@ -279,7 +279,7 @@ t.test('_globToQueryAndRegex', async (t) => {
     }
 
     try {
-        _globToQueryAndRegex('***');
+        globToQueryAndRegex('***');
         t.true(false, 'three stars should have thrown but did not');
     } catch (err) {
         if (err instanceof ValidationError) {
@@ -454,7 +454,7 @@ t.test('queryByGlobAsync', async (t) => {
 //================================================================================
 // TEMPLATES
 
-t.test('_parseTemplate and extractTemplateVariablesFromPath', (t: any) => {
+t.test('parseTemplate and extractTemplateVariablesFromPath', (t: any) => {
 
     type StringToString = Record<string, string>;
     interface ValidVector {
@@ -607,7 +607,7 @@ t.test('_parseTemplate and extractTemplateVariablesFromPath', (t: any) => {
                 t.true(true, `---  ${vector.template}  ---`);
                 t.true(true, `_parseTemplate...`);
                 // this should throw a ValidationError
-                let _thisShouldThrow = _parseTemplate(vector.template);
+                let _thisShouldThrow = parseTemplate(vector.template);
                 t.true(false, `${vector.template} - should throw a ValidationError but did not (_template...)`);
             } catch (err) {
                 if (err instanceof ValidationError) {
@@ -635,14 +635,14 @@ t.test('_parseTemplate and extractTemplateVariablesFromPath', (t: any) => {
             // should be valid
 
             t.true(true, `---  ${vector.template}  ---`);
-            let { varNames, glob, namedCaptureRegex } = _parseTemplate(vector.template);
+            let { varNames, glob, namedCaptureRegex } = parseTemplate(vector.template);
             t.same(varNames, vector.varNames, 'varNames should match');
             if (vector.glob !== undefined) {
                 t.same(glob, vector.glob, 'glob should match');
             }
 
             for (let [path, expectedVars] of Object.entries(vector.pathsAndExtractedVars)) {
-                let actualVars = _extractTemplateValuesUsingRe(namedCaptureRegex, path);
+                let actualVars = extractTemplateVariablesFromPathUsingRegex(namedCaptureRegex, path);
                 t.same(actualVars, expectedVars, `${path} - extracted variables should match (_matchRegexAndPath)`);
                 t.same(extractTemplateVariablesFromPath(vector.template, path), expectedVars, `${path} - extracted variables should match (matchTemplateAndPath)`);
             }

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -51,3 +51,14 @@ export let objWithoutUndefined = <T extends Record<string, any>>(obj: T): T => {
     }
     return obj2 as T;
 }
+
+// replace all occurrences of substring "from" with "to"
+export let replaceAll = (str: string, from: string, to: string): string => {
+    return str.split(from).join(to);
+};
+
+// how many times does the character occur in the string?
+export let countChars = (str: string, char: string) => {
+    if (char.length != 1) { throw new Error('char must have length 1 but is ' + JSON.stringify(char)); }
+    return str.split(char).length - 1;
+};


### PR DESCRIPTION
This introduces a new idea, **path templates**.  They look like this:
```js
    "/posts/{category}/{postId}.json"
```

You can use them to...

## Match against paths, and extract variables

```js
    "/posts/gardening/abc.json" --> { category: 'gardening', postId: 'abc' }

    "/something/else" --> null
```

## Query for documents

Templates can be auto-converted into globs...
```js
    "/posts/*/*.json"
```
...so that you can query Earthstar with them using the new glob functionality.

Some convenience functions do this for you:
```js
    let template = '/posts/{postId}.json';
    let docs = queryByTemplateSync(storage, template);
    let docs2 = await queryByTemplateAsync(asyncStorage, template);
```

## Details

Here are [precise details about what a "path template" string is](https://github.com/earthstar-project/earthstar/blob/templates/src/storage/queryHelpers.ts#L393-L431).  The most important detail is that they CANNOT match across `/` characters -- they're confined to one path segment, just like `*` (and unlike `**`).

## Bonus

You can mix and match templates and glob strings together!  This will work: `/posts/{postId}.*`