### PR TITLE
switch from multibase package to rfc4648 package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -348,12 +348,6 @@
         "@types/node": "*"
       }
     },
-    "@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "optional": true
-    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -626,14 +620,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "base64-arraybuffer": {
       "version": "0.1.4",
@@ -4223,16 +4209,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "multibase": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-2.0.0.tgz",
-      "integrity": "sha512-xIrqUVsinSlFjqj+OtEgCJ6MRl5hXjHMBPWsUt1ZGSRMx8rzm+7hCLE4wDeSA3COomlUC9zHCoUlvWjvAMtfDg==",
-      "requires": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0",
-        "web-encoding": "^1.0.2"
-      }
-    },
     "napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -5409,6 +5385,11 @@
       "requires": {
         "through": "~2.3.4"
       }
+    },
+    "rfc4648": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
+      "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
     },
     "rfdc": {
       "version": "1.3.0",
@@ -8062,14 +8043,6 @@
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.3.1.tgz",
       "integrity": "sha512-X4E7iPJzmMsL9AY4MyZrxUt0Dm/kGWreJEGdQgAHXHQrRGDdlwAu9X1LCsQ0VKUCg5wjwSS1LPpy1BOfxIw4Tw==",
       "dev": true
-    },
-    "web-encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
-      "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
-      "requires": {
-        "@zxing/text-encoding": "0.9.0"
-      }
     },
     "whatwg-fetch": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "fast-equals": "^2.0.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash.debounce": "^4.0.8",
-    "multibase": "^2.0.0",
+    "rfc4648": "^1.4.0",
     "tslib": "^2.0.3"
   }
 }

--- a/src/crypto/encoding.ts
+++ b/src/crypto/encoding.ts
@@ -1,4 +1,7 @@
-import multibase = require('multibase');
+import {
+    codec
+} from 'rfc4648';
+
 import {
     AuthorAddress,
     AuthorKeypair,
@@ -44,21 +47,37 @@ let assembleAuthorAddress = (shortname: AuthorShortname, encodedPubkey: EncodedK
  * 
  * The decoding must be strict (it doesn't allow a 1 in place of an i, etc).
  */
+
+const myEncoding = {
+    // this should match b32chars from characters.ts
+    chars: "abcdefghijklmnopqrstuvwxyz234567",
+    bits: 5,
+};
+
+/**
+ * Encode buffer to base32 string
+ */
 export let encodeBufferToBase32 = (buf: Buffer): Base32String =>
-    multibase.encode('base32', buf).toString();
+    'b' + codec.stringify(buf, myEncoding, { pad: false });
 
 /**
  * Decode base32 data to a Buffer.  Throw a ValidationError if the string is bad.
  */
 export let decodeBase32ToBuffer = (str: Base32String): Buffer => {
-    if (!str.startsWith('b')) { throw new ValidationError("can't decode base32 buffer - it should start with a 'b'. " + str); }
-    // enforce only lower case characters
-    // TODO: this is probably slow on large strings, probably faster to scan character by character?  or use regex?  need to benchmark it
-    if (str !== str.toLowerCase()) {
-        throw new ValidationError("can't decode base32 string - it contains uppercase characters");
+    if (!str.startsWith('b')) { throw new ValidationError("can't decode base32 string - it should start with a 'b'. " + str); }
+
+    // this library combines padding and looseness settings into a single "loose" option, so
+    // we have to set "loose: true" in order to handle unpadded inputs.
+    // with a custom codec, loose mode:
+    // -- allows padding or no padding -- we have to check for this
+    // -- does not allow uppercase -- good
+    // -- does not allow 1/i substitution -- good
+
+    // make sure no padding characters are on the end
+    if (str[str.length-1] === '=') {
+        throw new ValidationError("can't decode base32 string - it contains padding characters ('=')");
     }
-    // this can also throw an Error('invalid base32 character')
-    return multibase.decode(str);
+    return codec.parse(str.slice(1), myEncoding, { loose: true, out: Buffer.alloc as any }) as any as Buffer;
 };
 
 export let encodePubkey = encodeBufferToBase32;


### PR DESCRIPTION
We were using an older version of [`js-multibase`](https://www.npmjs.com/package/multibase).  The new version had switched from node Buffers to Browser style Uint8Arrays and was causing some trouble when trying to bundle Create Web Apps that didn't use Typescript.

Switch to the [`rfc4648`](https://www.npmjs.com/package/rfc4648) package instead.  It's more tightly focused to the encodings we need and I feel better about it.

I confirmed that this passes browser tests but haven't confirmed it solves the Create Web App bundle problem.

Thanks to khubo for PR #119 which got stuck on `package-lock.json` issues and I've fixed.