### PR TITLE
Update links to use new docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ Join our community on the [Earthstar Discord](https://discord.gg/FuaAnNqUfZ)
 ## Links and docs
 
 Docs for everyone:
-* **[A Guided Tour of Earthstar](docs/tour.md)** -- Slides and diagrams explaining how it works
+* **[A Guided Tour of Earthstar](https://earthstar-docs.netlify.app/docs/)** -- Slides and diagrams explaining how it works
 
 Docs for app developers:
-* [Overview for developers](docs/overview.md) -- A quick comparison between Earthstar, CouchDB, and SSB
-* [Rules of Earthstar](docs/rules-of-earthstar.md) -- The scope of the project, and details of the technical invariants of the distributed system.
-* [Tutorial](docs/tutorial.md) -- Make a Todo list app, step by step
+* [Overview for developers](https://earthstar-docs.netlify.app/docs/intro/overview-for-developers) -- A quick comparison between Earthstar, CouchDB, and SSB
+* [Rules of Earthstar](https://earthstar-docs.netlify.app/docs/intro/rules-of-earthstar) -- The scope of the project, and details of the technical invariants of the distributed system.
+* [Tutorial](https://earthstar-docs.netlify.app/docs/tutorials/making-an-app) -- Make a Todo list app, step by step
 * [Invite code format](https://github.com/earthstar-project/earthstar/wiki/Invite-code-format)
 * [Standard paths and data formats used by apps](https://github.com/earthstar-project/earthstar/wiki/Standard-paths-and-data-formats-used-by-apps) for their Earthstar documents, so apps can interoperate
 
 Docs for core Earthstar developers:
-* [Earthstar Specification](docs/specification.md) -- All you need to know to write an Earthstar implementation from scratch
-* [About syncing](docs/syncing.md) -- Exploring this topic in more detail
-* [About fancy conflict resolution](docs/fancy-conflict-resolution.md) -- How to add more complex conflict tracking on top of Earthstar
-* [About timestamps](docs/timestamps.md) -- Exploring the limits of Earthstar's assumptions about timestamps
-* [Urls](docs/urls.md) -- How to build URLs related to Earthstar
+* [Earthstar Specification](https://earthstar-docs.netlify.app/docs/reference/earthstar-specification) -- All you need to know to write an Earthstar implementation from scratch
+* [About syncing](https://earthstar-docs.netlify.app/docs/articles/syncing) -- Exploring this topic in more detail
+* [About fancy conflict resolution](https://earthstar-docs.netlify.app/docs/articles/fancier-conflict-resolution) -- How to add more complex conflict tracking on top of Earthstar
+* [About timestamps](https://earthstar-docs.netlify.app/docs/articles/timestamps) -- Exploring the limits of Earthstar's assumptions about timestamps
+* [Urls](https://earthstar-docs.netlify.app/docs/_old/urls) -- How to build URLs related to Earthstar
 
 Related repos:
 * [earthstar-cli](https://github.com/earthstar-project/earthstar-cli) -- Command line utility
@@ -128,7 +128,7 @@ Each database instance can hold a subset of the entire data, specified by a quer
 
 The universe of data is divided into **workspaces** -- collections of documents accessed by certain users.  Syncing happens one workspace at a time.
 
-Read the [vocabulary and concepts](docs/vocabulary.md) documentation for more about workspaces.
+Read the [vocabulary and concepts](https://earthstar-docs.netlify.app/docs/intro/concepts-and-vocabulary) documentation for more about workspaces.
 
 ## Editing data; multiple users and devices; conflicts
 


### PR DESCRIPTION
I updated any docs/$FILE link in the README to point instead to the
earthstar-docs.netlify.app site, if that page existed on the site.

## What's the problem you solved?
This PR is in response to #120.  It does not fully address the issue, as it does not cover the points in [@cinnamon-bun's 24 April comment](https://github.com/earthstar-project/earthstar/issues/120#issuecomment-826004075). I do not yet have enough context to tackle those points, but still wanted to help!

There are a few remaining references to docs. Specifically, there are a number of images used in the longer introduction in the README.  These images are in the [earthstar-docs repo](https://github.com/earthstar-project/earthstar-docs/tree/main/docs/_img), but in a folder that doesn't seem to be served up by the Docosaurus site. There is also a link to a page that seems to have been removed (docs/serialization-and-hashing.md).  I would be happy to fix these too if yous would like!

## What solution are you recommending?
new links!