### PR TITLE
added ability to copy documents from one workspace to another

### DIFF
--- a/src/extras.ts
+++ b/src/extras.ts
@@ -100,8 +100,9 @@ export let copyMyDocsToOtherWorkspace = async (sourceStorage: IStorage | IStorag
 
     storageLogger.log(`copying ${myDocs.length} docs authored by ${keypair.address} from ${sourceStorage.workspace} to ${destStorage.workspace}...`);
 
-    let numErrors = 0;
-    let numCopied = 0;
+    let numErrors   = 0;
+    let numIgnored  = 0;
+    let numCopied   = 0;
 
     // Write them to destStorage.  Modify the workspace property but preserve timestamps.
     for(let doc of myDocs) {
@@ -120,7 +121,7 @@ export let copyMyDocsToOtherWorkspace = async (sourceStorage: IStorage | IStorag
             numErrors += 1;
         } else if(result === WriteResult.Ignored) {
             storageLogger.log(`copying ${doc.path}... ignored`);
-            numErrors += 1;
+            numIgnored += 1;
         } else {
             storageLogger.log(`copying ${doc.path}... success`);
             numCopied += 1;
@@ -130,6 +131,7 @@ export let copyMyDocsToOtherWorkspace = async (sourceStorage: IStorage | IStorag
     // Check each write for errors and count how many succeed and fail.
     return {
         numCopied,
+        numIgnored,
         numErrors
     }
 }

--- a/src/test/extras.test.ts
+++ b/src/test/extras.test.ts
@@ -18,7 +18,7 @@ import { ValidatorEs4 } from '../validator/es4';
 import { StorageMemory } from '../storage/storageMemory';
 
 import { deleteMyDocuments } from '../extras';
-import { copyMyDocsToOtherWorkspace } from '..';
+import { copyMyDocsToOtherWorkspace } from '../extras';
 
 //================================================================================
 // prepare for test scenarios
@@ -185,7 +185,7 @@ for (let scenario of scenarios) {
 
         sourceStorage.close();
         destStorage.close();
-        
+
         t.end();
     });
 }

--- a/src/test/extras.test.ts
+++ b/src/test/extras.test.ts
@@ -150,23 +150,28 @@ for (let scenario of scenarios) {
         t.same(sourceStorage.set(keypair1, { format: FORMAT, path: '/path2!', content: 'val2 keypair1', timestamp: now - 10, deleteAfter: now + DAY }), WriteResult.Accepted, 'make ephemeral doc 2');
         t.equal(sourceStorage.getContent('/path2!'), 'val2 keypair1');
 
+        // a document from another author, to supercede the 'lone' doc
+        t.same(sourceStorage.set(keypair2, { format: FORMAT, path: '/path1', content: 'val1 keypair2', timestamp: now - 30 }), WriteResult.Accepted, 'overwrite doc 1 by second author...');
+        t.equal(sourceStorage.getContent('/path1'), 'val1 keypair2');
+
         // check that writes worked as expected
         t.same(sourceStorage.paths(), ['/path1', '/path2!'], 'paths() are correct');
         t.same(sourceStorage.paths({ contentLengthGt: 0 }), ['/path1', '/path2!'], 'two paths have non-empty content');
-        t.same(sourceStorage.authors(), [keypair1.address], 'authors() are correct');
+        t.same(sourceStorage.authors(), [keypair1.address, keypair2.address], 'authors() are correct');
 
         // copy the documents
-        let { numCopied, numErrors } = await copyMyDocsToOtherWorkspace(sourceStorage, destStorage, keypair1);
+        let { numCopied, numIgnored, numErrors } = await copyMyDocsToOtherWorkspace(sourceStorage, destStorage, keypair1);
 
         // check that copy succeeded
         t.same(numCopied, 2, '2 documents were copied');
         t.same(numErrors, 0, '0 errors');
+        t.same(numIgnored, 0, '0 ignored');
 
         // Check that the lone doc was copied
         t.equal(destStorage.getContent('/path1'), 'val1 keypair1', 'lone document was copied to dest storage');
         
-        // Check that the original lone document remains in the source storage
-        t.equal(sourceStorage.getContent('/path1'), 'val1 keypair1', 'original lone document still exists in source storage');
+        // Check that the original, superceded lone document remains in the source storage
+        t.equal(sourceStorage.getContent('/path1'), 'val1 keypair2', 'original superceded lone document still exists in source storage');
 
         // Check that the ephemeral doc was copied
         t.equal(destStorage.getContent('/path2!'), 'val2 keypair1', 'ephemeral document was copied to dest storage');
@@ -177,11 +182,14 @@ for (let scenario of scenarios) {
         // check that copy worked as expected
         t.same(destStorage.paths(), sourceStorage.paths(), 'dest paths() match source paths()');
         t.same(destStorage.paths({ contentLengthGt: 0 }), ['/path1', '/path2!'], 'two paths have non-empty content in dest');
-        t.same(destStorage.authors(), sourceStorage.authors(), 'dest authors() match sourc authors()');
+        t.same(destStorage.authors(), [keypair1.address], 'dest authors() match only the author for whom documents were copied');
         
-        // check that timestamps were preserved
-        t.same(destStorage.getDocument('/path1')?.timestamp, sourceStorage.getDocument('/path1')?.timestamp, '/path1 timestamps were preserved');
-        t.same(destStorage.getDocument('/path2!')?.timestamp, sourceStorage.getDocument('/path2!')?.timestamp, '/path2! timestamps were preserved');
+        // check that timestamps were preserved, but only for the author for whom the documents were copied
+        t.same(
+            [destStorage.getDocument('/path1')?.timestamp, destStorage.getDocument('/path2!')?.timestamp], 
+            sourceStorage.documents({history: 'all', author: keypair1.address}).map(doc => doc.timestamp), 
+            'timestamps were preserved'
+        );
 
         sourceStorage.close();
         destStorage.close();


### PR DESCRIPTION
## What's the problem you solved?

Added ability to copy documents from one workspace to another, as described in issue #74.  This solution ensures the author's identity cannot be changed and that timestamps are preserved.   

## What solution are you recommending?

Solution is provided per specification in issue #74.  This solution makes not attempt to remove the source documents after the copy.  All source documents are left intact.
