### PR TITLE
Add query helpers to universal exports

### DIFF
--- a/src/entries/universal.ts
+++ b/src/entries/universal.ts
@@ -19,6 +19,7 @@ export * from "../peer/peer.ts";
 
 export * from "../query/query-types.ts";
 export * from "../query/query.ts";
+export * from "../query/query-helpers.ts";
 
 export * from "../query-follower/query-follower-types.ts";
 export * from "../query-follower/query-follower.ts";


### PR DESCRIPTION
## What's the problem you solved?

Looks like the query helpers @tlowrimore added weren't being exported to end users!

## What solution are you recommending?

Added them to the universal entrypoint.