### PR TITLE
Check addresses

### DIFF
--- a/src/replica/replica.ts
+++ b/src/replica/replica.ts
@@ -1,5 +1,4 @@
 import { Lock, Superbus } from "../../deps.ts";
-
 import { Cmp } from "./util-types.ts";
 import { AuthorKeypair, Doc, DocToSet, LocalIndex, Path, ShareAddress } from "../util/doc-types.ts";
 import { HistoryMode, Query } from "../query/query-types.ts";
@@ -11,10 +10,10 @@ import {
     ReplicaId,
 } from "./replica-types.ts";
 import { IFormatValidator } from "../format-validators/format-validator-types.ts";
-
 import { isErr, ReplicaIsClosedError, ValidationError } from "../util/errors.ts";
 import { microsecondNow, randomId } from "../util/misc.ts";
 import { compareArrays } from "./compare.ts";
+import { checkShareIsValid } from "../core-validators/addresses.ts";
 
 import { Crypto } from "../crypto/crypto.ts";
 
@@ -61,9 +60,16 @@ export class Replica implements IReplica {
         validator: IFormatValidator,
         driver: IReplicaDriver,
     ) {
+        const addressIsValidResult = checkShareIsValid(share);
+
+        if (isErr(addressIsValidResult)) {
+            throw addressIsValidResult;
+        }
+
         logger.debug(
             `constructor.  driver = ${(driver as any)?.constructor?.name}`,
         );
+
         this.replicaId = "replica-" + randomId();
         this.share = share;
         this.formatValidator = validator;


### PR DESCRIPTION
## What's the problem you solved?

It was possible to instantiate `Replica`s with invalid share addresses.

## What solution are you recommending?

I have made it so that `Replica`s now throw a validation error when being constructed with an invalid share address. It is still possible to create ReplicaDrivers with invalid addresses, but I want to address how addresses are provided to drivers at another time so that they do not need to be provided twice.