### PR TITLE
Reuse query followers in ReplicaCache

### DIFF
--- a/src/replica/replica-cache.ts
+++ b/src/replica/replica-cache.ts
@@ -190,7 +190,7 @@ export class ReplicaCache {
             if (Date.now() > cachedResult.expires) {
                 this._replica.queryDocs(query).then((docs) => {
                     this._docCache.set(queryString, {
-                        follower,
+                        follower: cachedResult.follower,
                         docs,
                         expires: Date.now() + this._timeToLive,
                     });


### PR DESCRIPTION
## What's the problem you solved?

ReplicaCache was creating a new QueryFollower every time it was queried, even for the same query.
It was also referencing the follower before it had been declared.

## What solution are you recommending?

If a cached result is found, the existing query follower in the cache entry is used.