### PR TITLE
Improve network and resource efficiency of syncing

### DIFF
--- a/src/syncer/syncer-types.ts
+++ b/src/syncer/syncer-types.ts
@@ -32,8 +32,6 @@ export interface ShareState {
     partnerMaxLocalIndexOverall: number;
     partnerMaxLocalIndexSoFar: number; // -1 if unknown
     storageId: ReplicaId;
-    maxLocalIndexOverall: number;
-    maxLocalIndexSoFar: number; // -1 if unknown
     lastSeenAt: number;
 }
 

--- a/src/test/improved/syncer.test.ts
+++ b/src/test/improved/syncer.test.ts
@@ -66,7 +66,7 @@ function testSyncer(
             await writeRandomDocs(keypairA, targetStorage, 10);
 
             // Check if everything synced again
-            await sleep(1000);
+            await sleep(1500);
 
             await test.step({
                 name: "Storages synced (again)",


### PR DESCRIPTION
- Only have one active pull in a SyncCoordinator at a time
- Merge new share states from pull so that higher values always win
- Refactor a few loops using await to use Promise.all to run concurrently
