### PR TITLE
Fix maxLocalIndex hydration in LocalStorage, IndexedDB replica drivers.

### DIFF
--- a/src/replica/replica-driver-indexeddb.ts
+++ b/src/replica/replica-driver-indexeddb.ts
@@ -47,6 +47,7 @@ export class ReplicaDriverIndexedDB extends ReplicaDriverMemory {
             // dnt-shim-ignore
             const request = ((window as any).indexedDB as IDBFactory).open(
                 `earthstar:share:${this.share}`,
+                1,
             );
 
             request.onerror = () => {
@@ -87,6 +88,11 @@ export class ReplicaDriverIndexedDB extends ReplicaDriverMemory {
                     this.docsByPathNewestFirst = new Map(
                         Object.entries(docs.byPathNewestFirst),
                     );
+
+                    const localIndexes = Array.from(this.docByPathAndAuthor.values()).map((doc) =>
+                        doc._localIndex as number
+                    );
+                    this._maxLocalIndex = Math.max(...localIndexes);
 
                     return resolve(request.result);
                 };

--- a/src/replica/replica-driver-local-storage.ts
+++ b/src/replica/replica-driver-local-storage.ts
@@ -40,10 +40,10 @@ export class ReplicaDriverLocalStorage extends ReplicaDriverMemory {
         // but all docs are stored together inside this one item, as a giant JSON object
         this._localStorageKeyDocs = `stonesoup:documents:pathandauthor:${share}`;
 
-        let existingData = localStorage.getItem(this._localStorageKeyDocs);
+        const existingData = localStorage.getItem(this._localStorageKeyDocs);
         if (existingData !== null) {
             logger.debug("...constructor: loading data from localStorage");
-            let parsed = JSON.parse(existingData);
+            const parsed = JSON.parse(existingData);
 
             if (!isSerializedDriverDocs(parsed)) {
                 console.warn(
@@ -58,11 +58,17 @@ export class ReplicaDriverLocalStorage extends ReplicaDriverMemory {
             this.docsByPathNewestFirst = new Map(
                 Object.entries(parsed.byPathNewestFirst),
             );
+
+            const localIndexes = Array.from(this.docByPathAndAuthor.values()).map((doc) =>
+                doc._localIndex as number
+            );
+            this._maxLocalIndex = Math.max(...localIndexes);
         } else {
             logger.debug(
                 "...constructor: there was no existing data in localStorage",
             );
         }
+
         logger.debug("...constructor is done.");
     }
 
@@ -154,7 +160,7 @@ export class ReplicaDriverLocalStorage extends ReplicaDriverMemory {
 
     async upsert(doc: Doc): Promise<Doc> {
         if (this._isClosed) throw new ReplicaIsClosedError();
-        let upsertedDoc = await super.upsert(doc);
+        const upsertedDoc = await super.upsert(doc);
 
         // After every upsert, for now, we save everything
         // to localStorage as a single giant JSON blob.

--- a/src/replica/replica-driver-memory.ts
+++ b/src/replica/replica-driver-memory.ts
@@ -242,7 +242,7 @@ export class ReplicaDriverMemory implements IReplicaDriver {
     //--------------------------------------------------
     // SET
 
-    async upsert(doc: Doc): Promise<Doc> {
+    upsert(doc: Doc): Promise<Doc> {
         // add a doc.  don't enforce any rules on it.
         // overwrite existing doc even if this doc is older.
         // return a copy of the doc, frozen, with _localIndex set.
@@ -270,6 +270,6 @@ export class ReplicaDriverMemory implements IReplicaDriver {
         // save the list back to the index
         this.docsByPathNewestFirst.set(doc.path, docsByPath);
 
-        return doc;
+        return Promise.resolve(doc);
     }
 }

--- a/src/syncer/sync-coordinator.ts
+++ b/src/syncer/sync-coordinator.ts
@@ -43,6 +43,7 @@ export class SyncCoordinator {
             this.close();
         });
 
+        await this._getShareStates();
         await this.pull();
     }
 
@@ -50,8 +51,6 @@ export class SyncCoordinator {
         if (this.state === "closed") {
             return;
         }
-
-        await this._getShareStates();
 
         const docPulls = Object.keys(this._shareStates).map((key) => {
             return new Promise((resolve) => {

--- a/src/test/improved/syncer.test.ts
+++ b/src/test/improved/syncer.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "../asserts.ts";
+import { assert, assertEquals } from "../asserts.ts";
 import { Crypto } from "../../crypto/crypto.ts";
 import { AuthorKeypair } from "../../util/doc-types.ts";
 import { Peer } from "../../peer/peer.ts";
@@ -73,6 +73,8 @@ function testSyncer(
                 sanitizeOps: false,
                 sanitizeResources: false,
                 fn: async () => {
+                    const storageDocs = await storage.getLatestDocs();
+                    assertEquals(storageDocs.length, 40, "Storage has 40 docs");
                     assert(
                         await storagesAreSynced([storage, targetStorage]),
                         "storages synced (again)",

--- a/src/test/universal/sync-coordinator.test.ts
+++ b/src/test/universal/sync-coordinator.test.ts
@@ -79,6 +79,11 @@ Deno.test("SyncCoordinator", async () => {
     await sleep(100);
 
     assertEquals(coordinator.commonShares, [ADDRESS_A, ADDRESS_D]);
+    const storageADocs = await storageA1.getLatestDocs();
+    const storageDDocs = await storageD1.getLatestDocs();
+
+    assertEquals(storageADocs.length, 20, "Storage A1 contains 20 docs");
+    assertEquals(storageDDocs.length, 20, "Storage D1 contains 20 docs");
     assert(
         await storageHasAllStoragesDocs(storageA1, storageA2),
         `${ADDRESS_A} storages are synced.`,
@@ -92,6 +97,12 @@ Deno.test("SyncCoordinator", async () => {
     await writeRandomDocs(keypairB, storageD2, 10);
 
     await sleep(1000);
+
+    const storageADocsAgain = await storageA1.getLatestDocs();
+    const storageDDocsAgain = await storageD1.getLatestDocs();
+
+    assertEquals(storageADocsAgain.length, 30, "Storage A1 contains 30 docs");
+    assertEquals(storageDDocsAgain.length, 30, "Storage D1 contains 30 docs");
 
     assert(
         await storageHasAllStoragesDocs(storageA1, storageA2),


### PR DESCRIPTION
## What's the problem you solved?

New docs were being written with the wrong `localIndex` from both of these drivers, due to the `maxLocalIndex` not accounting for persisted docs. 

## What solution are you recommending?

Both LocalStorage and IndexedDB drivers now determine the maxLocalIndex using persisted docs, and a test has been added for this.