### PR TITLE
Add a function to sync a replica with a filesystem directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ example:
 	deno run ./example-app.ts
 
 test:
-	deno test --allow-net --allow-read src
+	deno test --allow-net --allow-read --allow-write --no-check=remote src
 
 test-watch:
 	deno test --watch --allow-net --allow-read src 

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -8,6 +8,7 @@ await build({
         { name: "./node", path: "./src/entries/node.ts" },
         { name: "./browser", path: "./src/entries/browser.ts" },
     ],
+    testPattern: "**/!(fs-sync)/*.test.{ts,tsx,js,mjs,jsx}",
     outDir: "./npm",
     shims: {
         deno: {

--- a/src/entries/deno.ts
+++ b/src/entries/deno.ts
@@ -1,2 +1,3 @@
 export { ReplicaDriverLocalStorage } from "../replica/replica-driver-local-storage.ts";
 export { ReplicaDriverSqlite } from "../replica/replica-driver-sqlite.deno.ts";
+export { syncReplicaAndFsDir } from "../sync-fs/sync-fs.ts";

--- a/src/sync-fs/constants.ts
+++ b/src/sync-fs/constants.ts
@@ -1,0 +1,19 @@
+export const MANIFEST_FILE_NAME = ".es-fs-manifest";
+export const ES4_MAX_CONTENT_LENGTH = 4000000;
+export const bytesExtensions = [
+  "gif",
+  "jpg",
+  "jpeg",
+  "png",
+  "mp3",
+  "mp4",
+  "mov",
+  "wav",
+  "webm",
+  "ogg",
+  "zip",
+  "rar",
+  "pdf",
+  "doc",
+  "docx",
+].map((ext) => `.${ext}`);

--- a/src/sync-fs/sync-fs-types.ts
+++ b/src/sync-fs/sync-fs-types.ts
@@ -1,0 +1,41 @@
+import { Replica } from "../replica/replica.ts";
+import { AuthorKeypair } from "../util/doc-types.ts";
+
+/**
+ * Options for syncing a replica with a filesystem directory.
+ * - `dirPath`: The filesystem path of the directory to be synced
+ * - `replica`: The replica to be synced with the directory
+ * - `keypair`: The keypair to be used to sign all writes derived from changes on the filesystem.
+ * - `allowDirtyDirWithoutManifest`: Whether to allow syncing of a folder with pre-existing contents which has never been synced before.
+ */
+export type SyncOptions = {
+    dirPath: string;
+    replica: Replica;
+    keypair: AuthorKeypair;
+    allowDirtyDirWithoutManifest: boolean;
+};
+
+export type Manifest = {
+    share: string;
+    entries: Record<string, FileInfoEntry | AbsenceEntry>;
+};
+
+export interface AbsenceEntry {
+    path: string;
+    fileLastSeenMs: number;
+    noticedOnMs: number;
+}
+
+export interface FileInfoEntry {
+    baseName: string;
+    dirName: string;
+    path: string;
+    abspath: string;
+    size: number;
+    contentsSize: number;
+    inode: number | null;
+    atimeMs: number | null; // access time (read)
+    mtimeMs: number | null; // modified time (write)
+    birthtimeMs: number | null; // created time
+    hash: string;
+}

--- a/src/sync-fs/sync-fs.ts
+++ b/src/sync-fs/sync-fs.ts
@@ -1,0 +1,309 @@
+import { encode } from "https://deno.land/std@0.126.0/encoding/base64.ts";
+import { walk } from "https://deno.land/std@0.132.0/fs/mod.ts";
+import {
+    basename,
+    dirname,
+    extname,
+    join,
+    relative,
+    resolve,
+} from "https://deno.land/std@0.132.0/path/mod.ts";
+import { Crypto } from "../crypto/crypto.ts";
+import { EarthstarError, isErr } from "../util/errors.ts";
+import { FormatValidatorEs4 } from "../format-validators/format-validator-es4.ts";
+import { bytesExtensions, ES4_MAX_CONTENT_LENGTH, MANIFEST_FILE_NAME } from "./constants.ts";
+import { FileInfoEntry, Manifest, SyncOptions } from "./sync-fs-types.ts";
+import {
+    dirBelongsToDifferentShare,
+    getDirAssociatedShare,
+    getTupleWinners,
+    hasFilesButNoManifest,
+    isAbsenceEntry,
+    isFileInfoEntry,
+    removeEmptyDir,
+    writeDocToDir,
+    writeEntryToReplica,
+    writeManifest,
+    zipByPath,
+} from "./util.ts";
+
+const textEncoder = new TextEncoder();
+
+export async function reconcileManifestWithDirContents(
+    fsDirPath: string,
+    forShare: string,
+): Promise<Manifest> {
+    // Open up existing manifest.
+    let manifest: Manifest = {
+        share: forShare,
+        entries: {},
+    };
+
+    try {
+        const contents = await Deno.readTextFile(
+            join(fsDirPath, MANIFEST_FILE_NAME),
+        );
+
+        manifest = JSON.parse(contents);
+    } catch {
+        // No manifest was present.
+    }
+
+    const fileEntries: Record<string, FileInfoEntry> = {};
+
+    for await (const entry of walk(fsDirPath)) {
+        if (entry.name === MANIFEST_FILE_NAME) {
+            continue;
+        }
+
+        if (entry.isFile) {
+            const { path } = entry;
+
+            const stat = await Deno.stat(path);
+            const extension = extname(path);
+
+            let contents = "";
+
+            if (bytesExtensions.includes(extension)) {
+                const fileContents = await Deno.readFile(path);
+                contents = encode(fileContents);
+            } else {
+                contents = await Deno.readTextFile(path);
+            }
+
+            const hash = await Crypto.sha256base32(contents);
+            const esPath = `/${relative(fsDirPath, path)}`;
+
+            const record: FileInfoEntry = {
+                baseName: basename(path),
+                dirName: dirname(path),
+                path: esPath,
+                abspath: resolve(path),
+                size: stat.size,
+                contentsSize: textEncoder.encode(contents).length,
+                inode: stat.ino,
+                atimeMs: stat.atime?.getTime() || null,
+                mtimeMs: stat.mtime?.getTime() || null,
+                birthtimeMs: stat.birthtime?.getTime() || null,
+                hash,
+            };
+
+            fileEntries[esPath] = record;
+        }
+    }
+
+    const zipped = zipByPath(manifest.entries, fileEntries);
+
+    const winners = getTupleWinners(zipped, (entryA, entryB) => {
+        // This shouldn't happen but let's get it out the way.
+        if (!entryA && !entryB) {
+            return entryA as never;
+        }
+
+        // Manifest entry exists but file has disappeared.
+        if (entryA && !entryB) {
+            // If the entry is an absence entry, that's still valid.
+            if (isAbsenceEntry(entryA)) {
+                return entryA;
+            }
+
+            return {
+                noticedOnMs: Date.now(),
+                fileLastSeenMs: entryA.mtimeMs || 0,
+                path: entryA.path,
+            };
+        }
+
+        // No manifest entry, but a file present.
+        if (!entryA && entryB) {
+            return entryB;
+        }
+
+        // An existing manifest entry AND a file present.
+        if (entryA && entryB) {
+            // If entryA is absence entry, B should win.
+            if (isAbsenceEntry(entryA)) {
+                return entryB;
+            }
+
+            const latestA = Math.max(
+                entryA.birthtimeMs || 0,
+                entryA.mtimeMs || 0,
+            );
+            const latestB = Math.max(
+                entryB.birthtimeMs || 0,
+                entryB.mtimeMs || 0,
+            );
+
+            if (latestA > latestB) {
+                return entryA;
+            }
+
+            return entryB;
+        }
+
+        // This should never happen.
+        return entryA as never;
+    });
+
+    const nextManifest: Manifest = {
+        share: forShare,
+        entries: {},
+    };
+
+    for (const path in winners) {
+        const entry = winners[path];
+
+        // All paths accounted for, none of them should return null.
+        if (!entry) {
+            console.error("This shouldn't happen!");
+            continue;
+        }
+
+        nextManifest.entries[path] = entry;
+    }
+
+    return nextManifest;
+}
+
+/*
+
+Outline of how this function works:
+
+1. The contents of the directory are compared with the manifest of that directory, and a new manifest is compiled.
+2. The latest docs from the replica are retrieved before any operations are performed.
+3. The entries from the manifest are iterated over, writing contents to the replica
+4. The docs retrieved from the replica earlier are iterated over, writing contents to the file system.
+
+*/
+
+/**
+ * Syncs an earthstar replica with a directory on the filesystem, representing Earthstar documents as files and vice versa. *Make sure you understand the changes this function could enact upon a given directory before using it, as it can delete files in certain circumstances.*
+ * - Changes from the filesystem which are superseded by writes from the replica will still be synced to the replica as an older version of the document, provided they were authored by different identities.
+ * - If a document has a certain extension (e.g. .jpg, .mp3), the syncer assumes the contents are base64 encoded when writing data to the filesystem.
+ * - If a file has a path containing a `!` (i.e. an ephemeral path), *it will be deleted unless a correspending document is found in the replica*.
+ */
+export async function syncReplicaAndFsDir(
+    opts: SyncOptions,
+) {
+    // Check if dir was every synced with a different share, throw if so.
+    if (await dirBelongsToDifferentShare(opts.dirPath, opts.replica.share)) {
+        const manifestShare = await getDirAssociatedShare(opts.dirPath);
+
+        throw new EarthstarError(
+            `Tried to sync a replica for ${opts.replica.share} with a directory which had been synced with ${manifestShare}`,
+        );
+    }
+
+    // Check if dir has files but no manifest
+    // and abort if a clean dir is required for no manifest.
+
+    if (
+        opts.allowDirtyDirWithoutManifest === false &&
+        await hasFilesButNoManifest(opts.dirPath)
+    ) {
+        throw new EarthstarError(
+            "Tried to sync a directory for the first time, but it was not empty.",
+        );
+    }
+
+    // First reconcile any existing manifest with the contents of the directory.
+    const reconciledManifest = await reconcileManifestWithDirContents(
+        opts.dirPath,
+        opts.replica.share,
+    );
+
+    const errors = [];
+
+    for (const key in reconciledManifest.entries) {
+        const entry = reconciledManifest.entries[key];
+
+        if (!entry) {
+            continue;
+        }
+
+        if (isAbsenceEntry(entry)) {
+            // Keypair is allowed to write this path
+            const canWriteToPath = FormatValidatorEs4
+                ._checkAuthorCanWriteToPath(opts.keypair.address, entry.path);
+
+            if (isErr(canWriteToPath)) {
+                errors.push(canWriteToPath);
+            }
+        }
+
+        if (isFileInfoEntry(entry)) {
+            // Keypair is allowed to write this path
+            const canWriteToPath = FormatValidatorEs4
+                ._checkAuthorCanWriteToPath(opts.keypair.address, entry.path);
+
+            // Path is valid
+            const pathIsValid = FormatValidatorEs4._checkPathIsValid(
+                entry.path,
+            );
+
+            // Size of file is not too big.
+            const sizeIsOkay = entry.contentsSize <= ES4_MAX_CONTENT_LENGTH;
+
+            if (isErr(canWriteToPath)) {
+                errors.push(canWriteToPath);
+            }
+
+            if (isErr(pathIsValid)) {
+                errors.push(pathIsValid);
+            }
+
+            if (!sizeIsOkay) {
+                errors.push(
+                    new EarthstarError(
+                        `File too big for the es.4 format: ${entry.path}`,
+                    ),
+                );
+            }
+        }
+    }
+
+    if (errors.length > 0) {
+        throw errors[0];
+    }
+
+    const latestDocsBeforeMerge = await opts.replica.getLatestDocs();
+
+    for (const path in reconciledManifest.entries) {
+        const entry = reconciledManifest.entries[path];
+
+        if (entry.path.indexOf("!") !== -1 && isFileInfoEntry(entry)) {
+            const correspondingEphemeralDoc = await opts.replica.getLatestDocAtPath(
+                path,
+            );
+
+            if (
+                !correspondingEphemeralDoc ||
+                (correspondingEphemeralDoc && correspondingEphemeralDoc.deleteAfter &&
+                    Date.now() * 1000 > correspondingEphemeralDoc.deleteAfter)
+            ) {
+                await Deno.remove(entry.abspath);
+                await removeEmptyDir(entry.dirName);
+                continue;
+            }
+        }
+
+        await writeEntryToReplica(entry, opts.replica, opts.keypair);
+    }
+
+    for (const doc of latestDocsBeforeMerge) {
+        // Make sure not to re-write any ephemeral docs to the filesystem.
+        if (doc.deleteAfter && Date.now() * 1000 > doc.deleteAfter) {
+            return;
+        }
+
+        await writeDocToDir(doc, opts.dirPath);
+    }
+
+    const manifestAfterOps = await reconcileManifestWithDirContents(
+        opts.dirPath,
+        opts.replica.share,
+    );
+
+    await writeManifest(manifestAfterOps, opts.dirPath);
+}

--- a/src/sync-fs/util.ts
+++ b/src/sync-fs/util.ts
@@ -1,0 +1,220 @@
+import { MANIFEST_FILE_NAME } from "./constants.ts";
+import { AbsenceEntry, FileInfoEntry, Manifest } from "./sync-fs-types.ts";
+import { dirname, extname, join } from "https://deno.land/std@0.132.0/path/mod.ts";
+import { decode, encode } from "https://deno.land/std@0.126.0/encoding/base64.ts";
+import { bytesExtensions } from "./constants.ts";
+import { ensureDir } from "https://deno.land/std@0.132.0/fs/mod.ts";
+import { AuthorKeypair, Doc } from "../util/doc-types.ts";
+import { Replica } from "../replica/replica.ts";
+
+export function isAbsenceEntry(
+    o: AbsenceEntry | FileInfoEntry | Doc,
+): o is AbsenceEntry {
+    if ("noticedOnMs" in o) {
+        return true;
+    }
+
+    return false;
+}
+
+export function isFileInfoEntry(
+    o: AbsenceEntry | FileInfoEntry | Doc,
+): o is FileInfoEntry {
+    if ("inode" in o) {
+        return true;
+    }
+
+    return false;
+}
+
+export function isDoc(
+    o: AbsenceEntry | FileInfoEntry | Doc,
+): o is Doc {
+    if ("signature" in o) {
+        return true;
+    }
+
+    return false;
+}
+
+export async function hasFilesButNoManifest(
+    fsDirPath: string,
+): Promise<boolean> {
+    try {
+        await Deno.stat(join(fsDirPath, MANIFEST_FILE_NAME));
+
+        // Manifest is present.
+        return false;
+    } catch {
+        // Manifest is not present.
+        const items = [];
+        for await (const dirEntry of Deno.readDir(fsDirPath)) {
+            items.push(dirEntry);
+        }
+
+        // Return whether there are any files present.
+        return items.length > 0;
+    }
+}
+
+export async function dirBelongsToDifferentShare(
+    dirPath: string,
+    shareAddress: string,
+) {
+    try {
+        const contents = await Deno.readTextFile(join(dirPath, MANIFEST_FILE_NAME));
+        const manifest: Manifest = JSON.parse(contents);
+
+        return manifest.share !== shareAddress;
+    } catch {
+        return false;
+    }
+}
+
+export function writeManifest(manifest: Manifest, dirPath: string) {
+    return Deno.writeTextFile(
+        join(dirPath, MANIFEST_FILE_NAME),
+        JSON.stringify(manifest),
+    );
+}
+
+export async function getDirAssociatedShare(
+    dirPath: string,
+) {
+    try {
+        const contents = await Deno.readTextFile(join(dirPath, MANIFEST_FILE_NAME));
+        const manifest: Manifest = JSON.parse(contents);
+
+        return manifest.share;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Take two sets of items organised by share path and zip them up into a record of tuples organised by paths.
+ */
+export function zipByPath<TypeA, TypeB>(
+    aRecord: Record<string, TypeA>,
+    bRecord: Record<string, TypeB>,
+): Record<string, [TypeA | null, TypeB | null]> {
+    const newRecord: Record<string, [TypeA | null, TypeB | null]> = {};
+
+    for (const path in aRecord) {
+        const value = aRecord[path];
+        newRecord[path] = [value, null];
+    }
+
+    for (const path in bRecord) {
+        const value = bRecord[path];
+
+        const maybeExisting = newRecord[path];
+
+        if (maybeExisting) {
+            newRecord[path] = [maybeExisting[0], value];
+            continue;
+        }
+
+        newRecord[path] = [null, value];
+    }
+
+    return newRecord;
+}
+
+export function getTupleWinners<TypeA, TypeB>(
+    zippedRecord: Record<string, [TypeA | null, TypeB | null]>,
+    determineWinner: (a: TypeA | null, b: TypeB | null) => TypeA | TypeB,
+): Record<string, (TypeA | TypeB)> {
+    const winners: Record<string, (TypeA | TypeB)> = {};
+
+    for (const path in zippedRecord) {
+        const [a, b] = zippedRecord[path];
+
+        const winner = determineWinner(a, b);
+
+        winners[path] = winner;
+    }
+
+    return winners;
+}
+
+export async function writeDocToDir(doc: Doc, dir: string) {
+    const pathToWrite = join(dir, doc.path);
+    const extension = extname(doc.path);
+    const enclosingDir = dirname(pathToWrite);
+
+    if (doc.content.length === 0) {
+        try {
+            await Deno.remove(join(dir, doc.path));
+            return removeEmptyDir(enclosingDir);
+        } catch {
+            // Document is gone from the FS already.
+            return;
+        }
+    }
+
+    await ensureDir(enclosingDir);
+
+    if (bytesExtensions.includes(extension)) {
+        const contents = decode(doc.content);
+
+        return Deno.writeFile(pathToWrite, contents);
+    }
+
+    return Deno.writeTextFile(pathToWrite, doc.content);
+}
+
+export async function removeEmptyDir(dir: string) {
+    try {
+        await Deno.remove(dir);
+    } catch {
+        // There was something in there.
+    }
+}
+
+export async function writeEntryToReplica(
+    entry: FileInfoEntry | AbsenceEntry,
+    replica: Replica,
+    keypair: AuthorKeypair,
+) {
+    if (isAbsenceEntry(entry)) {
+        return replica.set(keypair, {
+            path: entry.path,
+            content: "",
+            format: "es.4",
+        });
+    }
+
+    const extension = extname(entry.path);
+
+    const correspondingDoc = await replica.getLatestDocAtPath(entry.path);
+    const deleteAfter = correspondingDoc ? correspondingDoc.deleteAfter : null;
+
+    if (correspondingDoc && deleteAfter && Date.now() * 1000 > deleteAfter) {
+        await Deno.remove(entry.abspath);
+        return removeEmptyDir(entry.dirName);
+    }
+
+    if (!bytesExtensions.includes(extension)) {
+        const content = await Deno.readTextFile(entry.abspath);
+        const timestamp = entry.mtimeMs ? entry.mtimeMs * 1000 : undefined;
+
+        return replica.set(keypair, {
+            path: entry.path,
+            format: "es.4",
+            content,
+            deleteAfter,
+            timestamp,
+        });
+    }
+
+    const content = await Deno.readFile(entry.abspath);
+    const base64Content = encode(content);
+
+    return replica.set(keypair, {
+        path: entry.path,
+        format: "es.4",
+        content: base64Content,
+        deleteAfter,
+    });
+}

--- a/src/test/fs-sync/reconcile_manifest.test.ts
+++ b/src/test/fs-sync/reconcile_manifest.test.ts
@@ -1,0 +1,183 @@
+import { emptyDir, ensureDir } from "https://deno.land/std@0.132.0/fs/mod.ts";
+import { join } from "https://deno.land/std@0.132.0/path/mod.ts";
+import {
+    assert,
+    assertEquals,
+    assertNotEquals,
+} from "https://deno.land/std@0.132.0/testing/asserts.ts";
+import { MANIFEST_FILE_NAME } from "../../sync-fs/constants.ts";
+import { reconcileManifestWithDirContents } from "../../sync-fs/sync-fs.ts";
+import { FileInfoEntry, Manifest } from "../../sync-fs/sync-fs-types.ts";
+import { isAbsenceEntry } from "../../sync-fs/util.ts";
+
+const TEST_DIR = "src/test/fs-sync/dirs/reconcile_manifest";
+const TEST_SHARE = "+test.a123";
+
+Deno.test("reconcileManifestWithDirContents", async (test) => {
+    await ensureDir(TEST_DIR);
+    await emptyDir(TEST_DIR);
+
+    await test.step("From an empty dir.", async () => {
+        const manifest = await reconcileManifestWithDirContents(
+            TEST_DIR,
+            TEST_SHARE,
+        );
+        assert(Object.keys(manifest.entries).length === 0);
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Check that the manifest has an entry for each file
+    await test.step("From initial reconciliation (with no manifest)", async () => {
+        // Write a simple file structure.
+        await writeSampleDirContents(TEST_DIR);
+        const manifest = await reconcileManifestWithDirContents(
+            TEST_DIR,
+            TEST_SHARE,
+        );
+
+        assertEquals(
+            Object.keys(manifest.entries).sort(),
+            ["/a.txt", "/b.txt", "/c.txt", "/w/x.txt", "/w/y.txt", "/w/z.txt"],
+            "Manifest contains an entry for each path.",
+        );
+
+        await writeManifest(TEST_DIR, manifest);
+    });
+
+    // Check that the manifest adds an absence entry after a file is deleted.
+    await test.step("After removing a file", async () => {
+        await Deno.remove(join(TEST_DIR, "b.txt"));
+        const { entries, share } = await reconcileManifestWithDirContents(
+            TEST_DIR,
+            TEST_SHARE,
+        );
+
+        assertEquals(share, TEST_SHARE, "Manifest has correct share name");
+
+        assertEquals(
+            Object.keys(entries).sort(),
+            ["/a.txt", "/b.txt", "/c.txt", "/w/x.txt", "/w/y.txt", "/w/z.txt"],
+            "Manifest contains an entry for each path.",
+        );
+
+        assert(isAbsenceEntry(entries["/b.txt"]), "/b.txt is an absence entry");
+        assert(
+            !isAbsenceEntry(entries["/a.txt"]),
+            "/a.txt is NOT an absence entry",
+        );
+        assert(
+            !isAbsenceEntry(entries["/c.txt"]),
+            "/.txt is NOT an absence entry",
+        );
+        assert(
+            !isAbsenceEntry(entries["/w/x.txt"]),
+            "/w/x.txt is NOT an absence entry",
+        );
+        assert(
+            !isAbsenceEntry(entries["/w/y.txt"]),
+            "/w/y.txt is NOT an absence entry",
+        );
+        assert(
+            !isAbsenceEntry(entries["/w/z.txt"]),
+            "/w/z.txt is NOT an absence entry",
+        );
+    });
+
+    let prevZEntry: FileInfoEntry | null = null;
+
+    await test.step("After re-adding a file", async () => {
+        await Deno.writeTextFile(join(TEST_DIR, "b.txt"), "I'm back baby");
+
+        const { entries, share } = await reconcileManifestWithDirContents(
+            TEST_DIR,
+            TEST_SHARE,
+        );
+
+        assertEquals(share, TEST_SHARE, "Manifest has correct share name");
+
+        assertEquals(
+            Object.keys(entries).sort(),
+            ["/a.txt", "/b.txt", "/c.txt", "/w/x.txt", "/w/y.txt", "/w/z.txt"],
+            "Manifest contains an entry for each path.",
+        );
+
+        assert(
+            !isAbsenceEntry(entries["/b.txt"]),
+            "/b.txt is NOT an absence entry",
+        );
+        assert(
+            !isAbsenceEntry(entries["/a.txt"]),
+            "/a.txt is NOT an absence entry",
+        );
+
+        assert(
+            !isAbsenceEntry(entries["/c.txt"]),
+            "/.txt is NOT an absence entry",
+        );
+        assert(
+            !isAbsenceEntry(entries["/w/x.txt"]),
+            "/w/x.txt is NOT an absence entry",
+        );
+        assert(
+            !isAbsenceEntry(entries["/w/y.txt"]),
+            "/w/y.txt is NOT an absence entry",
+        );
+        assert(
+            !isAbsenceEntry(entries["/w/z.txt"]),
+            "/w/z.txt is NOT an absence entry",
+        );
+
+        // We'll remember that for the next test.
+        prevZEntry = entries["/w/z.txt"];
+    });
+
+    await test.step("After updating a file", async () => {
+        await Deno.writeTextFile(join(TEST_DIR, "w", "z.txt"), "Updated!");
+
+        const { entries, share } = await reconcileManifestWithDirContents(
+            TEST_DIR,
+            TEST_SHARE,
+        );
+
+        assertEquals(share, TEST_SHARE, "Manifest has correct share name");
+
+        assertEquals(
+            Object.keys(entries).sort(),
+            ["/a.txt", "/b.txt", "/c.txt", "/w/x.txt", "/w/y.txt", "/w/z.txt"],
+            "Manifest contains an entry for each path.",
+        );
+
+        assert(
+            !isAbsenceEntry(entries["/w/z.txt"]),
+            "/w/z.txt is NOT an absence entry",
+        );
+
+        assertNotEquals(
+            prevZEntry,
+            entries["/w/z.txt"],
+            "Entry for /w/z.txt has changed",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+});
+
+export function writeManifest(dirPath: string, manifest: Manifest) {
+    return Deno.writeTextFile(
+        join(dirPath, MANIFEST_FILE_NAME),
+        JSON.stringify(manifest),
+    );
+}
+
+export async function writeSampleDirContents(dirPath: string) {
+    await Deno.writeTextFile(join(dirPath, "a.txt"), "Hello!");
+    await Deno.writeTextFile(join(dirPath, "b.txt"), "Hi!");
+    await Deno.writeTextFile(join(dirPath, "c.txt"), "Yo!");
+
+    await ensureDir(join(dirPath, "w"));
+
+    await Deno.writeTextFile(join(dirPath, "w", "x.txt"), "Hello!");
+    await Deno.writeTextFile(join(dirPath, "w", "y.txt"), "Hi!");
+    await Deno.writeTextFile(join(dirPath, "w", "z.txt"), "Yo!");
+}

--- a/src/test/fs-sync/sync_share_dir.test.ts
+++ b/src/test/fs-sync/sync_share_dir.test.ts
@@ -1,0 +1,618 @@
+import { emptyDir, ensureDir } from "https://deno.land/std@0.132.0/fs/mod.ts";
+import { join } from "https://deno.land/std@0.132.0/path/mod.ts";
+import {
+    assert,
+    assertEquals,
+    assertNotEquals,
+    assertRejects,
+} from "https://deno.land/std@0.132.0/testing/asserts.ts";
+import { ES4_MAX_CONTENT_LENGTH, MANIFEST_FILE_NAME } from "../../sync-fs/constants.ts";
+import { syncReplicaAndFsDir } from "../../sync-fs/sync-fs.ts";
+import { Manifest } from "../../sync-fs/sync-fs-types.ts";
+import { decode, encode } from "https://deno.land/std@0.126.0/encoding/base64.ts";
+import { Crypto } from "../../crypto/crypto.ts";
+import { AuthorKeypair } from "../../util/doc-types.ts";
+import { Replica } from "../../replica/replica.ts";
+import { ReplicaDriverMemory } from "../../replica/replica-driver-memory.ts";
+import { FormatValidatorEs4 } from "../../format-validators/format-validator-es4.ts";
+
+const TEST_DIR = "src/test/fs-sync/dirs/sync_share_dir";
+const TEST_SHARE = "+test.a123";
+
+function makeReplica(address: string) {
+    const driver = new ReplicaDriverMemory(address);
+    return new Replica(
+        address,
+        FormatValidatorEs4,
+        driver,
+    );
+}
+
+Deno.test("syncShareAndDir", async (test) => {
+    const keypairA = await Crypto.generateAuthorKeypair(
+        "aaaa",
+    ) as AuthorKeypair;
+    const keypairB = await Crypto.generateAuthorKeypair(
+        "bbbb",
+    ) as AuthorKeypair;
+
+    // Throws if the dir is dirty and there is no manifest + the option is on.
+
+    await ensureDir(TEST_DIR);
+    await emptyDir(TEST_DIR);
+    await Deno.writeTextFile(join(TEST_DIR, "dirty.txt"), "heh");
+
+    await test.step("can't sync a dirty folder without a manifest", async () => {
+        await assertRejects(
+            () => {
+                return syncReplicaAndFsDir({
+                    dirPath: TEST_DIR,
+                    allowDirtyDirWithoutManifest: false,
+                    keypair: keypairA,
+                    replica: makeReplica(TEST_SHARE),
+                });
+            },
+            undefined,
+            "Tried to sync a directory for the first time, but it was not empty.",
+            "throws on trying to sync dirty folder without a manifest",
+        );
+
+        assertEquals(
+            await syncReplicaAndFsDir({
+                allowDirtyDirWithoutManifest: true,
+                dirPath: TEST_DIR,
+                keypair: keypairA,
+                replica: makeReplica(TEST_SHARE),
+            }),
+            undefined,
+            "does not throw on trying to sync dirty folder without manifest when manually overridden",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Throws if the replica address does not match the manifest address
+
+    await test.step("can't sync a directory which was synced with another share", async () => {
+        const otherReplica = makeReplica("+other.b123");
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: false,
+            keypair: keypairA,
+            replica: makeReplica(TEST_SHARE),
+        });
+
+        await assertRejects(
+            () => {
+                return syncReplicaAndFsDir({
+                    dirPath: TEST_DIR,
+                    allowDirtyDirWithoutManifest: false,
+                    keypair: keypairA,
+                    replica: otherReplica,
+                });
+            },
+            undefined,
+            "Tried to sync a replica for",
+            "throws when trying to sync with a folder which had been synced with another share",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Throws if you try to change a file at an owned path
+    await test.step("throws when you try to change a file at someone else's owned path", async () => {
+        const ownedPath = join(TEST_DIR, `~${keypairB.address}`);
+
+        await ensureDir(ownedPath);
+        await Deno.writeTextFile(
+            join(ownedPath, "mine.txt"),
+            "Ho",
+        );
+
+        await assertRejects(
+            () => {
+                return syncReplicaAndFsDir({
+                    dirPath: TEST_DIR,
+                    allowDirtyDirWithoutManifest: true,
+                    keypair: keypairA,
+                    replica: makeReplica(TEST_SHARE),
+                });
+            },
+            undefined,
+            `author ${keypairA.address} can't write to path`,
+            "throws when trying to write a file at someone's else's own path",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Throws if you try to delete a file at an owned path
+    await test.step("throws when you try to delete a file at someone else's owned path", async () => {
+        const ownedPath = join(TEST_DIR, `~${keypairB.address}`);
+
+        await ensureDir(ownedPath);
+
+        const manifest: Manifest = {
+            share: TEST_SHARE,
+            entries: {
+                [`/~${keypairB.address}/mine.txt`]: {
+                    noticedOnMs: 0,
+                    fileLastSeenMs: 0,
+                    path: `/~${keypairB.address}/mine.txt`,
+                },
+            },
+        };
+
+        await Deno.writeTextFile(
+            join(TEST_DIR, MANIFEST_FILE_NAME),
+            JSON.stringify(manifest),
+        );
+
+        await assertRejects(
+            () => {
+                return syncReplicaAndFsDir({
+                    dirPath: TEST_DIR,
+                    allowDirtyDirWithoutManifest: false,
+                    keypair: keypairA,
+                    replica: makeReplica(TEST_SHARE),
+                });
+            },
+            undefined,
+            `author ${keypairA.address} can't write to path`,
+            "throws when trying to delete a file at someone's else's own path",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Throws if a file has an invalid path
+    await test.step("throws when you write a file at an invalid path", async () => {
+        const invalidPath = join(TEST_DIR, `/@invalid.png`);
+
+        await Deno.writeTextFile(
+            invalidPath,
+            "!",
+        );
+
+        await assertRejects(
+            () => {
+                return syncReplicaAndFsDir({
+                    dirPath: TEST_DIR,
+                    allowDirtyDirWithoutManifest: true,
+                    keypair: keypairA,
+                    replica: makeReplica(TEST_SHARE),
+                });
+            },
+            undefined,
+            `invalid path`,
+            "throws when trying to write an invalid path",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Throws if a file is too big
+    await test.step("throws when files are too big", async () => {
+        const bytes = Uint8Array.from(Array(ES4_MAX_CONTENT_LENGTH + 100));
+        await Deno.writeFile(join(TEST_DIR, "big.jpg"), bytes);
+
+        await assertRejects(
+            () => {
+                return syncReplicaAndFsDir({
+                    dirPath: TEST_DIR,
+                    allowDirtyDirWithoutManifest: true,
+                    keypair: keypairA,
+                    replica: makeReplica(TEST_SHARE),
+                });
+            },
+            undefined,
+            `File too big for the es.4 format`,
+            "throws because big.jpg is too big",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Writes from fs -> replica
+    await test.step("writes files from the fs -> replica", async () => {
+        await Deno.writeTextFile(
+            join(TEST_DIR, "text.txt"),
+            "A",
+        );
+
+        await ensureDir(join(TEST_DIR, "sub"));
+
+        await Deno.writeTextFile(
+            join(TEST_DIR, "sub", "text.txt"),
+            "B",
+        );
+
+        const replica = makeReplica(TEST_SHARE);
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        const textDoc = await replica.getLatestDocAtPath("/text.txt");
+
+        assert(textDoc);
+        assertEquals(textDoc?.content, "A", "Content of /text.txt is as expected");
+
+        const subTextDoc = await replica.getLatestDocAtPath("/sub/text.txt");
+
+        assert(subTextDoc);
+        assertEquals(
+            subTextDoc?.content,
+            "B",
+            "Content of /sub/text.txt is as expected",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Writes docs from replica -> fs
+    await test.step("writes files from the replica -> fs", async () => {
+        const replica = makeReplica(TEST_SHARE);
+
+        await replica.set(keypairB, {
+            content: "A",
+            path: "/text.txt",
+            format: "es.4",
+        });
+
+        await replica.set(keypairB, {
+            content: "B",
+            path: "/sub/text.txt",
+            format: "es.4",
+        });
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        const textContents = await Deno.readTextFile(join(TEST_DIR, "text.txt"));
+        assertEquals(textContents, "A", "Content of /text.txt is as expected");
+
+        const subTextContents = await Deno.readTextFile(
+            join(TEST_DIR, "sub", "text.txt"),
+        );
+        assertEquals(
+            subTextContents,
+            "B",
+            "Content of /sub/text.txt is as expected",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Deletes files from the FS we'd expect it to.
+    await test.step("wiped docs on replica -> deleted file on the fs", async () => {
+        const replica = makeReplica(TEST_SHARE);
+
+        await replica.set(keypairB, {
+            content: "A",
+            path: "/to-delete.txt",
+            format: "es.4",
+        });
+
+        await replica.set(keypairB, {
+            content: "A",
+            path: "/sub/to-delete.txt",
+            format: "es.4",
+        });
+
+        await replica.set(keypairB, {
+            content: "A",
+            path: "/sub2/to-delete.txt",
+            format: "es.4",
+        });
+
+        await replica.set(keypairB, {
+            content: "A",
+            path: "/sub2/dont-delete.txt",
+            format: "es.4",
+        });
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        await replica.set(keypairB, {
+            content: "",
+            path: "/to-delete.txt",
+            format: "es.4",
+        });
+
+        await replica.set(keypairB, {
+            content: "",
+            path: "/sub/to-delete.txt",
+            format: "es.4",
+        });
+
+        await replica.set(keypairB, {
+            content: "",
+            path: "/sub2/to-delete.txt",
+            format: "es.4",
+        });
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        await assertRejects(
+            () => {
+                return Deno.stat(join(TEST_DIR, "to-delete.txt"));
+            },
+            undefined,
+            undefined,
+            "/to-delete.txt is gone",
+        );
+
+        await assertRejects(
+            () => {
+                return Deno.stat(join(TEST_DIR, "sub", "to-delete.txt"));
+            },
+            undefined,
+            undefined,
+            "/sub/to-delete.txt is gone",
+        );
+
+        await assertRejects(
+            () => {
+                return Deno.stat(join(TEST_DIR, "sub"));
+            },
+            undefined,
+            undefined,
+            `tried to read deleted ${join(TEST_DIR, "sub")} folder`,
+        );
+
+        await assertRejects(
+            () => {
+                return Deno.stat(join(TEST_DIR, "sub2", "to-delete.txt"));
+            },
+            undefined,
+            undefined,
+            "/sub2/to-delete.txt is gone",
+        );
+
+        assert(await Deno.stat(join(TEST_DIR, "sub2", "dont-delete.txt")));
+    });
+
+    await emptyDir(TEST_DIR);
+
+    // Wipes docs from the replica we'd expect it to.
+    await test.step("deleted files on the fs -> wiped doc on replica", async () => {
+        const replica = makeReplica(TEST_SHARE);
+
+        await replica.set(keypairB, {
+            content: "A",
+            path: "/to-delete.txt",
+            format: "es.4",
+        });
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        await Deno.remove(join(TEST_DIR, "to-delete.txt"));
+
+        await assertRejects(
+            () => {
+                return Deno.stat(join(TEST_DIR, "to-delete.txt"));
+            },
+            undefined,
+            undefined,
+            "/to-delete.txt is gone from the fs",
+        );
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        const toDeleteDoc = await replica.getLatestDocAtPath("/to-delete.txt");
+
+        assertEquals(toDeleteDoc?.content, "", "/to-delete.txt was wiped");
+
+        // Does not delete a doc which was written to replica-side since last sync
+        await replica.set(keypairB, {
+            content: "A",
+            path: "/will-return.txt",
+            format: "es.4",
+        });
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        await Deno.remove(join(TEST_DIR, "will-return.txt"));
+
+        await replica.set(keypairB, {
+            content: "B",
+            path: "/will-return.txt",
+            format: "es.4",
+        });
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        const returnedContents = await Deno.readTextFile(
+            join(TEST_DIR, "will-return.txt"),
+        );
+
+        assertEquals(returnedContents, "B");
+
+        // Deletes docs which have expired replica-side
+
+        await replica.set(keypairB, {
+            content: "!!!",
+            path: "/!ephemeral.txt",
+            format: "es.4",
+            deleteAfter: (Date.now() * 1000) + (1000 * 1000),
+        });
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        const ephemeralContents = await Deno.readTextFile(
+            join(TEST_DIR, "!ephemeral.txt"),
+        );
+
+        assertEquals(ephemeralContents, "!!!");
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 1500);
+        });
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        await assertRejects(
+            () => {
+                return Deno.readTextFile(join(TEST_DIR, "!ephemeral.txt"));
+            },
+            undefined,
+            undefined,
+            "reading ephemeral doc which should have been deleted.",
+        );
+
+        // Deletes ephemeral files without corresponding doc
+
+        await Deno.writeTextFile(join(TEST_DIR, "!ephemeral2.txt"), "!!!");
+
+        await syncReplicaAndFsDir({
+            dirPath: TEST_DIR,
+            allowDirtyDirWithoutManifest: true,
+            keypair: keypairA,
+            replica,
+        });
+
+        const ephemeralDoc = await replica.getLatestDocAtPath("/!ephemeral2.txt");
+        assertEquals(
+            ephemeralDoc,
+            undefined,
+            "replica does not have ephemeral doc defined from fs",
+        );
+
+        await assertRejects(
+            () => {
+                return Deno.readTextFile(join(TEST_DIR, "!ephemeral,.txt"));
+            },
+            undefined,
+            undefined,
+            "ephemeral doc defined on fs-side is gone",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+
+    await test.step("stores older versions of docs from the fs", async () => {
+        const replica = makeReplica(TEST_SHARE);
+
+        await Deno.writeTextFile(
+            join(TEST_DIR, "wiki.txt"),
+            "B",
+        );
+
+        await replica.set(keypairA, {
+            content: "A",
+            path: "/wiki.txt",
+            format: "es.4",
+        });
+
+        await syncReplicaAndFsDir({
+            allowDirtyDirWithoutManifest: true,
+            dirPath: TEST_DIR,
+            keypair: keypairB,
+            replica: replica,
+        });
+
+        const versions = await replica.getAllDocsAtPath("/wiki.txt");
+
+        assertEquals(versions.length, 2, "There are two versions of wiki.txt");
+
+        const contents = versions.map(({ content }) => content).sort();
+
+        assertEquals(contents, ["A", "B"], "contents of versions are as expected");
+    });
+
+    await emptyDir(TEST_DIR);
+
+    await test.step("converts certain file formats from base64 to binary", async () => {
+        await Deno.writeTextFile(join(TEST_DIR, "pic.jpg"), "JPG_DATA");
+
+        const replica = makeReplica(TEST_SHARE);
+
+        await replica.set(keypairB, {
+            path: "/pic.png",
+            content: encode("PNG_DATA"),
+            format: "es.4",
+        });
+
+        await syncReplicaAndFsDir({
+            allowDirtyDirWithoutManifest: true,
+            dirPath: TEST_DIR,
+            keypair: keypairA,
+            replica,
+        });
+
+        const jpgDoc = await replica.getLatestDocAtPath("/pic.jpg");
+
+        assertNotEquals(
+            "JPG_DATA",
+            jpgDoc?.content,
+            "data written to replica is not same as that in file",
+        );
+
+        const decoder = new TextDecoder();
+
+        assertEquals(
+            "JPG_DATA",
+            decoder.decode(decode(jpgDoc?.content || "")),
+            "doc content was encoded to base64",
+        );
+
+        const pngData = await Deno.readFile(join(TEST_DIR, "pic.png"));
+
+        assertEquals(
+            "PNG_DATA",
+            decoder.decode(pngData),
+            "file content was decoded from base64",
+        );
+    });
+
+    await emptyDir(TEST_DIR);
+});


### PR DESCRIPTION
This adds a new function called `syncReplicaAndFsDir`, which synchronises an Earthstar replica with a filesystem directory.

- Earthstar docs are written to the filesystem as files, and changes from the filesystem are written onto the replica.
- Changes from the filesystem are also set with timestamps, so even if a file is overwritten by an external change (i.e. a friend making a change to a document), the previous content from the file will still be persisted to the replica as one of the document's versions. This gives us scope for some form of conflict resolution.
- Some extra bookkeeping is done using a hidden manifest file stored at `.es-fs-manifest` at the root of the folder being synced.

A few caveats, as the mapping from the filesystem to Earthstar is not perfect:

- The function will throw if a file larger than 4mb is present in the directory (this is the limit of the ES4 format - watch this space)
- The function will throw if a change is made at a path owned by an identity other than the one provided to the function.
- The function will throw if a change is made at a path considered invalid by Earthstar (e.g. starting with a `@`)

For the moment this function is exclusive to the Deno distribution. Theoretically it can be automatically mapped to the Node version, but there are some issues I'm trying to resolve.