### PR TITLE
Fix some syncing issues related to historyMode 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 	deno test --allow-net --allow-read --allow-write --no-check=remote src
 
 test-watch:
-	deno test --watch --allow-net --allow-read src 
+	deno test --watch --allow-net --allow-read --no-check=remote src 
 
 test-coverage:
 	deno test --no-check --coverage=cov_profile src

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ example:
 	deno run ./example-app.ts
 
 test:
-	deno test --allow-net --allow-read --allow-write --no-check=remote src
+	deno test --allow-net --allow-read --allow-write src
 
 test-watch:
-	deno test --watch --allow-net --allow-read --no-check=remote src 
+	deno test --watch --allow-net --allow-read src 
 
 test-coverage:
 	deno test --no-check --coverage=cov_profile src

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -53,13 +53,13 @@ await build({
     },
     // typeCheck: false,
     mappings: {
-        "https://esm.sh/earthstar-streaming-rpc@4.0.1": {
+        "https://esm.sh/earthstar-streaming-rpc@4.0.3": {
             name: "earthstar-streaming-rpc",
-            version: "4.0.1",
+            version: "4.0.3",
         },
-        "https://deno.land/x/earthstar_streaming_rpc@v4.0.1/src/entries/node.ts": {
+        "https://deno.land/x/earthstar_streaming_rpc@v4.0.3/src/entries/node.ts": {
             name: "earthstar-streaming-rpc",
-            version: "4.0.1",
+            version: "4.0.3",
             subPath: "node",
         },
         "./src/streaming_rpc/streaming_rpc.ts": "./src/streaming_rpc/streaming_rpc.node.ts",

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -7,7 +7,7 @@ import { stringLengthInBytes } from "../util/bytes.ts";
 //--------------------------------------------------
 
 import { Logger } from "../util/log.ts";
-let logger = new Logger("query", "greenBright");
+const logger = new Logger("query", "greenBright");
 
 //================================================================================
 
@@ -23,12 +23,12 @@ export function cleanUpQuery(inputQuery: Query): CleanUpQueryResult {
     // check for filters that obviously result in nothing and return a canonical empty query: { limit: 0 }
 
     // apply default values
-    let query = { ...DEFAULT_QUERY, ...inputQuery };
+    const query = { ...DEFAULT_QUERY, ...inputQuery };
 
     //--------------------------------------------------
     // VALIDITY
 
-    let invalidResponse: CleanUpQueryResult = {
+    const invalidResponse: CleanUpQueryResult = {
         query: { limit: 0 },
         isValid: false,
         willMatch: "nothing",
@@ -122,7 +122,7 @@ export function cleanUpQuery(inputQuery: Query): CleanUpQueryResult {
 
     // filter combinations that result in no matches --> nothing
     if (query.filter !== undefined) {
-        let filter = query.filter;
+        const filter = query.filter;
         if (
             filter.path && filter.pathStartsWith &&
             !filter.path.startsWith(filter.pathStartsWith)
@@ -229,7 +229,7 @@ export function docMatchesFilter(doc: Doc, filter: QueryFilter): boolean {
     ) {
         return false;
     }
-    let contentLength = stringLengthInBytes(doc.content);
+    const contentLength = stringLengthInBytes(doc.content);
     if (
         filter.contentLength !== undefined &&
         contentLength !== filter.contentLength

--- a/src/streaming_rpc/streaming_rpc.node.ts
+++ b/src/streaming_rpc/streaming_rpc.node.ts
@@ -3,5 +3,5 @@ export {
     type ITransport,
     TransportHttpClient,
     TransportLocal,
-} from "https://esm.sh/earthstar-streaming-rpc@4.0.1";
-export { TransportWebsocketClient } from "https://esm.sh/earthstar-streaming-rpc@4.0.1/browser";
+} from "https://esm.sh/earthstar-streaming-rpc@4.0.3";
+export { TransportWebsocketClient } from "https://esm.sh/earthstar-streaming-rpc@4.0.3/browser";

--- a/src/streaming_rpc/streaming_rpc.ts
+++ b/src/streaming_rpc/streaming_rpc.ts
@@ -4,4 +4,4 @@ export {
     TransportHttpClient,
     TransportLocal,
     TransportWebsocketClient,
-} from "https://deno.land/x/earthstar_streaming_rpc@v4.0.1/mod.browser.ts";
+} from "https://deno.land/x/earthstar_streaming_rpc@v4.0.3/mod.browser.ts";

--- a/src/syncer/sync-coordinator.ts
+++ b/src/syncer/sync-coordinator.ts
@@ -58,6 +58,7 @@ export class SyncCoordinator {
 
                 this._pullDocs({
                     query: {
+                        historyMode: "all",
                         orderBy: "localIndex ASC",
                         startAfter: {
                             localIndex: state.partnerMaxLocalIndexSoFar,

--- a/src/test/improved/replica-driver.test.ts
+++ b/src/test/improved/replica-driver.test.ts
@@ -406,6 +406,22 @@ export function runReplicaDriverTests(scenario: TestScenario) {
             const vectors: Vector[] = [
                 {
                     query: {
+                        historyMode: "latest",
+                        orderBy: "localIndex ASC",
+                        startAfter: { localIndex: -1 },
+                    },
+                    expectedContent: ["Hello 1"],
+                },
+                {
+                    query: {
+                        historyMode: "all",
+                        startAfter: { localIndex: -1 },
+                        orderBy: "localIndex ASC",
+                    },
+                    expectedContent: ["Hello 1", "Hello 3", "Hello 4"],
+                },
+                {
+                    query: {
                         historyMode: "all",
                         orderBy: "localIndex ASC",
                     },

--- a/src/test/improved/replica-driver.test.ts
+++ b/src/test/improved/replica-driver.test.ts
@@ -18,7 +18,7 @@ let J = JSON.stringify;
 export function runReplicaDriverTests(scenario: TestScenario) {
     const SUBTEST_NAME = scenario.name;
 
-    Deno.test(`${SUBTEST_NAME}: validates addresses`, () => {
+    Deno.test(`${SUBTEST_NAME}: validates addresses`, async () => {
         if (scenario.persistent) {
             const validShare = "+gardening.abcde";
             const invalidShare = "PEANUTS.123";
@@ -30,7 +30,7 @@ export function runReplicaDriverTests(scenario: TestScenario) {
             const storage = scenario.makeDriver(validShare);
             assert(storage);
 
-            storage.close(true);
+            await storage.close(true);
         }
     });
 

--- a/src/test/improved/syncer.test.ts
+++ b/src/test/improved/syncer.test.ts
@@ -43,6 +43,18 @@ function testSyncer(
             await writeRandomDocs(keypairA, storage, 10);
             await writeRandomDocs(keypairB, targetStorage, 10);
 
+            // Also write some docs to the same path to make sure all versions of docs are synced.
+            await storage.set(keypairA, {
+                content: "Written by A",
+                path: "/popular-path",
+                format: "es.4",
+            });
+            await targetStorage.set(keypairB, {
+                content: "Written by B",
+                path: "/popular-path",
+                format: "es.4",
+            });
+
             // Create Syncers
             const syncer = new Syncer(scenario.clientPeer, () => scenario.clientTransport);
             const otherSyncer = new Syncer(scenario.targetPeer, () => scenario.targetTransport);
@@ -73,8 +85,8 @@ function testSyncer(
                 sanitizeOps: false,
                 sanitizeResources: false,
                 fn: async () => {
-                    const storageDocs = await storage.getLatestDocs();
-                    assertEquals(storageDocs.length, 40, "Storage has 40 docs");
+                    const storageDocs = await storage.getAllDocs();
+                    assertEquals(storageDocs.length, 42, "Storage has 42 docs");
                     assert(
                         await storagesAreSynced([storage, targetStorage]),
                         "storages synced (again)",

--- a/src/test/improved/syncer.test.ts
+++ b/src/test/improved/syncer.test.ts
@@ -69,6 +69,8 @@ function testSyncer(
                 sanitizeOps: false,
                 sanitizeResources: false,
                 fn: async () => {
+                    const storageDocs = await storage.getAllDocs();
+                    assertEquals(storageDocs.length, 22, "Storage has 22 docs");
                     assert(await storagesAreSynced([storage, targetStorage]), "storages synced");
                 },
             });

--- a/src/test/rpc-dep-node.ts
+++ b/src/test/rpc-dep-node.ts
@@ -1,2 +1,2 @@
-export * from "https://esm.sh/earthstar-streaming-rpc@4.0.1";
-export * from "https://deno.land/x/earthstar_streaming_rpc@v4.0.1/src/entries/node.ts";
+export * from "https://esm.sh/earthstar-streaming-rpc@4.0.3";
+export * from "https://deno.land/x/earthstar_streaming_rpc@v4.0.3/src/entries/node.ts";

--- a/src/test/test-deps.ts
+++ b/src/test/test-deps.ts
@@ -1,3 +1,3 @@
 export { serve } from "https://deno.land/std@0.123.0/http/server.ts";
-export { type Opine, opine } from "https://deno.land/x/opine@2.1.1/mod.ts";
-export * as Rpc from "https://deno.land/x/earthstar_streaming_rpc@v4.0.1/mod.ts";
+export { type Opine, opine } from "https://deno.land/x/opine@2.1.5/mod.ts";
+export * as Rpc from "https://deno.land/x/earthstar_streaming_rpc@v4.0.3/mod.ts";

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -48,8 +48,32 @@ export function docsAreEquivalent(docsA: Doc[], docsB: Doc[]) {
         return false;
     }
 
-    const aStripped = docsA.map(stripLocalIndexFromDoc);
-    const bStripped = docsB.map(stripLocalIndexFromDoc);
+    const sortByPathThenAuthor = (docA: Doc, docB: Doc) => {
+        const { path: pathA, author: authorA } = docA;
+        const { path: pathB, author: authorB } = docB;
+
+        if (pathA < pathB) {
+            return -1;
+        }
+
+        if (pathA > pathB) {
+            return 1;
+        }
+
+        if (authorA < authorB) {
+            return -1;
+        }
+
+        if (authorA > authorB) {
+            return 1;
+        }
+
+        // Shouldn't happen.
+        return 0 as never;
+    };
+
+    const aStripped = docsA.map(stripLocalIndexFromDoc).sort(sortByPathThenAuthor);
+    const bStripped = docsB.map(stripLocalIndexFromDoc).sort(sortByPathThenAuthor);
 
     return deepEqual(aStripped, bStripped);
 }
@@ -83,7 +107,6 @@ export async function storagesAreSynced(storages: Replica[]): Promise<boolean> {
     // Create an array where each element is a collection of all the docs from a storage.
     for await (const storage of storages) {
         const allDocs = await storage.getAllDocs();
-
         allDocsSets.push(allDocs);
     }
 

--- a/src/test/universal/sync-coordinator.test.ts
+++ b/src/test/universal/sync-coordinator.test.ts
@@ -49,6 +49,29 @@ Deno.test("SyncCoordinator", async () => {
     targetPeer.addReplica(storageC2);
     targetPeer.addReplica(storageD2);
 
+    // Write some docs to the same path so that we test all history being synced.
+    await storageA1.set(keypairA, {
+        content: "Written by A",
+        path: "/popular-path",
+        format: "es.4",
+    });
+    await storageA2.set(keypairB, {
+        content: "Written by B",
+        path: "/popular-path",
+        format: "es.4",
+    });
+    await storageD1.set(keypairA, {
+        content: "Written by A",
+        path: "/popular-path",
+        format: "es.4",
+    });
+    await storageD2.set(keypairB, {
+        content: "Written by B",
+        path: "/popular-path",
+        format: "es.4",
+    });
+
+    // And a bunch more for good measure.
     await writeRandomDocs(keypairA, storageA1, 10);
     await writeRandomDocs(keypairB, storageA2, 10);
     await writeRandomDocs(keypairA, storageD1, 10);
@@ -79,11 +102,11 @@ Deno.test("SyncCoordinator", async () => {
     await sleep(100);
 
     assertEquals(coordinator.commonShares, [ADDRESS_A, ADDRESS_D]);
-    const storageADocs = await storageA1.getLatestDocs();
-    const storageDDocs = await storageD1.getLatestDocs();
+    const storageADocs = await storageA1.getAllDocs();
+    const storageDDocs = await storageD1.getAllDocs();
 
-    assertEquals(storageADocs.length, 20, "Storage A1 contains 20 docs");
-    assertEquals(storageDDocs.length, 20, "Storage D1 contains 20 docs");
+    assertEquals(storageADocs.length, 22, "Storage A1 contains 22 docs");
+    assertEquals(storageDDocs.length, 22, "Storage D1 contains 22 docs");
     assert(
         await storageHasAllStoragesDocs(storageA1, storageA2),
         `${ADDRESS_A} storages are synced.`,
@@ -98,11 +121,11 @@ Deno.test("SyncCoordinator", async () => {
 
     await sleep(1000);
 
-    const storageADocsAgain = await storageA1.getLatestDocs();
-    const storageDDocsAgain = await storageD1.getLatestDocs();
+    const storageADocsAgain = await storageA1.getAllDocs();
+    const storageDDocsAgain = await storageD1.getAllDocs();
 
-    assertEquals(storageADocsAgain.length, 30, "Storage A1 contains 30 docs");
-    assertEquals(storageDDocsAgain.length, 30, "Storage D1 contains 30 docs");
+    assertEquals(storageADocsAgain.length, 32, "Storage A1 contains 32 docs");
+    assertEquals(storageDDocsAgain.length, 32, "Storage D1 contains 32 docs");
 
     assert(
         await storageHasAllStoragesDocs(storageA1, storageA2),


### PR DESCRIPTION
- Made syncer query for `historyMode: 'all'` when querying another replica.
- Added tests to make sure writes to the same paths are being synced correctly, updated utils to properly check syncedness of different replicas.
- Upgrade earthstar-streaming-rpc to 4.0.3, fixing a typechecking issue with Opine.
