### PR TITLE
Filesystem sync fixes and improvements

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "test": "deno test --allow-net --allow-read --allow-write src",
-    "test-watch": "deno test --watch --allow-net --allow-read src",
+    "test-watch": "deno test --watch --allow-net --allow-read --allow-write src",
     "bundle": "deno bundle --no-check=remote ./mod.browser.ts ./earthstar.bundle.js",
     "npm": "deno run --allow-all scripts/build_npm.ts",
     "run-bundle": "deno run --allow-all ./earthstar.bundle.js --help",

--- a/src/sync-fs/constants.ts
+++ b/src/sync-fs/constants.ts
@@ -1,5 +1,12 @@
 export const MANIFEST_FILE_NAME = ".es-fs-manifest";
+
 export const ES4_MAX_CONTENT_LENGTH = 4000000;
+
+export const IGNORED_FILES = [
+  MANIFEST_FILE_NAME,
+  ".DS_Store",
+];
+
 export const bytesExtensions = [
   "gif",
   "jpg",

--- a/src/sync-fs/sync-fs.ts
+++ b/src/sync-fs/sync-fs.ts
@@ -14,6 +14,7 @@ import { FormatValidatorEs4 } from "../format-validators/format-validator-es4.ts
 import {
   bytesExtensions,
   ES4_MAX_CONTENT_LENGTH,
+  IGNORED_FILES,
   MANIFEST_FILE_NAME,
 } from "./constants.ts";
 import { FileInfoEntry, Manifest, SyncOptions } from "./sync-fs-types.ts";
@@ -56,7 +57,7 @@ export async function reconcileManifestWithDirContents(
   const fileEntries: Record<string, FileInfoEntry> = {};
 
   for await (const entry of walk(fsDirPath)) {
-    if (entry.name === MANIFEST_FILE_NAME) {
+    if (IGNORED_FILES.includes(entry.name)) {
       continue;
     }
 


### PR DESCRIPTION
- Fixes an issue where documents at owned paths were being erroneously seen as modified
- Fixes an issue where files which were deleted from the filesystem would be resurrected after sync
- Make the file syncer ignore `.DS_Store` 🙄