### PR TITLE
Improve filesystem sync timestamp heuristic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ example:
 	deno run ./example-app.ts
 
 test:
-	deno test --allow-net --allow-read --allow-write src
+	deno test --allow-all src
 
 test-watch:
-	deno test --watch --allow-net --allow-read src 
+	deno test --watch --allow-all src 
 
 test-coverage:
 	deno test --no-check --coverage=cov_profile src

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
-    "test": "deno test --allow-net --allow-read --allow-write src",
-    "test-watch": "deno test --watch --allow-net --allow-read --allow-write src",
+    "test": "deno test --allow-all src",
+    "test-watch": "deno test --watch --allow-all src",
     "bundle": "deno bundle --no-check=remote ./mod.browser.ts ./earthstar.bundle.js",
     "npm": "deno run --allow-all scripts/build_npm.ts",
     "run-bundle": "deno run --allow-all ./earthstar.bundle.js --help",

--- a/src/sync-fs/sync-fs-types.ts
+++ b/src/sync-fs/sync-fs-types.ts
@@ -23,18 +23,14 @@ export type Manifest = {
 export interface AbsenceEntry {
   path: string;
   fileLastSeenMs: number;
-  noticedOnMs: number;
 }
 
 export interface FileInfoEntry {
-  baseName: string;
   dirName: string;
   path: string;
   abspath: string;
   size: number;
   contentsSize: number;
-  inode: number | null;
-  atimeMs: number | null; // access time (read)
   mtimeMs: number | null; // modified time (write)
   birthtimeMs: number | null; // created time
   hash: string;

--- a/src/sync-fs/sync-fs.ts
+++ b/src/sync-fs/sync-fs.ts
@@ -1,7 +1,6 @@
 import { encode } from "https://deno.land/std@0.126.0/encoding/base64.ts";
 import { walk } from "https://deno.land/std@0.132.0/fs/mod.ts";
 import {
-  basename,
   dirname,
   extname,
   join,
@@ -80,14 +79,11 @@ export async function reconcileManifestWithDirContents(
       const esPath = `/${relative(fsDirPath, path)}`;
 
       const record: FileInfoEntry = {
-        baseName: basename(path),
         dirName: dirname(path),
         path: esPath,
         abspath: resolve(path),
         size: stat.size,
         contentsSize: textEncoder.encode(contents).length,
-        inode: stat.ino,
-        atimeMs: stat.atime?.getTime() || null,
         mtimeMs: stat.mtime?.getTime() || null,
         birthtimeMs: stat.birthtime?.getTime() || null,
         hash,
@@ -113,7 +109,6 @@ export async function reconcileManifestWithDirContents(
       }
 
       return {
-        noticedOnMs: Date.now(),
         fileLastSeenMs: entryA.mtimeMs || 0,
         path: entryA.path,
       };

--- a/src/sync-fs/util.ts
+++ b/src/sync-fs/util.ts
@@ -18,7 +18,7 @@ import { Replica } from "../replica/replica.ts";
 export function isAbsenceEntry(
   o: AbsenceEntry | FileInfoEntry | Doc,
 ): o is AbsenceEntry {
-  if ("noticedOnMs" in o) {
+  if ("fileLastSeenMs" in o) {
     return true;
   }
 
@@ -28,7 +28,7 @@ export function isAbsenceEntry(
 export function isFileInfoEntry(
   o: AbsenceEntry | FileInfoEntry | Doc,
 ): o is FileInfoEntry {
-  if ("inode" in o) {
+  if ("abspath" in o) {
     return true;
   }
 

--- a/src/test/fs-sync/sync_share_dir.test.ts
+++ b/src/test/fs-sync/sync_share_dir.test.ts
@@ -152,6 +152,58 @@ Deno.test("syncShareAndDir", async (test) => {
       `author ${keypairA.address} can't write to path`,
       "throws when trying to write a file at someone's else's own path",
     );
+
+    replica.close(true);
+
+    await emptyDir(TEST_DIR);
+
+    const replica2 = makeReplica(TEST_SHARE);
+
+    // Want to guard against a specific sequence of events.
+    await replica2.set(keypairB, {
+      path: `/~${keypairB.address}/special-case.txt`,
+      content: "A",
+      format: "es.4",
+    });
+
+    await syncReplicaAndFsDir({
+      dirPath: TEST_DIR,
+      allowDirtyDirWithoutManifest: true,
+      keypair: keypairA,
+      replica: replica2,
+    });
+
+    await replica2.set(keypairB, {
+      path: `/~${keypairB.address}/special-case.txt`,
+      content: "B",
+      format: "es.4",
+    });
+
+    const specialCasePath = join(
+      TEST_DIR,
+      `~${keypairB.address}`,
+      `special-case.txt`,
+    );
+
+    const touch = Deno.run({ cmd: ["touch", specialCasePath] });
+    await touch.status();
+    touch.close();
+
+    // This shouldn't throw.
+    await syncReplicaAndFsDir({
+      dirPath: TEST_DIR,
+      allowDirtyDirWithoutManifest: true,
+      keypair: keypairA,
+      replica: replica2,
+    });
+
+    const specialContents = await Deno.readTextFile(specialCasePath);
+
+    assertEquals(
+      specialContents,
+      "B",
+      "Document at owned path is new value, even though it was modified out of order.",
+    );
   });
 
   await emptyDir(TEST_DIR);

--- a/src/test/fs-sync/sync_share_dir.test.ts
+++ b/src/test/fs-sync/sync_share_dir.test.ts
@@ -166,7 +166,6 @@ Deno.test("syncShareAndDir", async (test) => {
       share: TEST_SHARE,
       entries: {
         [`/~${keypairB.address}/mine.txt`]: {
-          noticedOnMs: 0,
           fileLastSeenMs: 0,
           path: `/~${keypairB.address}/mine.txt`,
         },


### PR DESCRIPTION
## What's the problem you solved?

This fix addresses this sequence of events:

```
0000: (Remote) /@ownd/doc.txt set to A
0500: (FS local): /@ownd/doc.txt synced to fs as A
1000: (Remote) @/ownd/doc.txt set to B
2000: (FS Local) doc.txt touched by fs (still A), mtime updated.
3000: Sync attempted - fails due to old value.
```

## What solution are you recommending?

The solution was to only update sync manifest entries' modified time properties if the content hash has changed since last time.