### PR TITLE
Refactor sync pulls a little

### DIFF
--- a/src/syncer/_syncer-bag.ts
+++ b/src/syncer/_syncer-bag.ts
@@ -278,11 +278,11 @@ export function makeSyncerBag(
           ...existingShareStates,
           [share]: {
             ...myShareState,
-            partnerMaxLocalIndexSoFar: pulled.length > 0
-              ? Math.max(
-                ...pulled.map(({ localIndex }) => localIndex),
-              )
-              : myShareState.partnerMaxLocalIndexSoFar,
+            partnerMaxLocalIndexOverall: response.partnerMaxLocalIndexOverall,
+            partnerMaxLocalIndexSoFar: Math.max(
+              ...pulled.map(({ localIndex }) => localIndex),
+              myShareState.partnerMaxLocalIndexSoFar,
+            ),
             lastSeenAt: microsecondNow(),
           },
         },

--- a/src/test/universal/sync-coordinator.test.ts
+++ b/src/test/universal/sync-coordinator.test.ts
@@ -103,7 +103,7 @@ Deno.test("SyncCoordinator", async () => {
 
   await coordinator.start();
 
-  await sleep(100);
+  await sleep(500);
 
   assertEquals(coordinator.commonShares, [ADDRESS_A, ADDRESS_D]);
   const storageADocs = await storageA1.getAllDocs();


### PR DESCRIPTION
This makes it so that pulls for share states and queries are made separately depending on whether they are caught up or not. Also fixes an issue where the maxLocalIndexOverall of the other side was not being calculated properly.
