### PR TITLE
SyncFsOptions: added overwriteFilesAtOwnedPath option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# next
+
+- Added 'overwriteFilesAtOwnedPaths' option to SyncFsOptions. This will forcibly
+  overwrite any files at paths owned by other identities with ones from the
+  replica.
+
 # 9.1.0
 
 - Added a `pulled` property to syncer statuses.

--- a/src/peer/peer.ts
+++ b/src/peer/peer.ts
@@ -111,9 +111,9 @@ export class Peer implements IPeer {
   private subscribeSyncerStatuses<TransportType extends ITransport<SyncerBag>>(
     syncer: Syncer<TransportType>,
   ) {
-    syncer.syncStatuses.bus.on("*", () => {
+    syncer.syncStatuses.bus.on("*", async () => {
       for (const [connectionDesc, statuses] of syncer.syncStatuses.entries()) {
-        this.syncerStatuses.set(connectionDesc, statuses);
+        await this.syncerStatuses.set(connectionDesc, statuses);
       }
     });
 

--- a/src/sync-fs/sync-fs-types.ts
+++ b/src/sync-fs/sync-fs-types.ts
@@ -8,14 +8,15 @@ import { AuthorKeypair } from "../util/doc-types.ts";
  * - `keypair`: The keypair to be used to sign all writes derived from changes on the filesystem.
  * - `allowDirtyDirWithoutManifest`: Whether to allow syncing of a folder with pre-existing contents which has never been synced before.
  */
-export type SyncOptions = {
+export type SyncFsOptions = {
   dirPath: string;
   replica: Replica;
   keypair: AuthorKeypair;
   allowDirtyDirWithoutManifest: boolean;
+  overwriteFilesAtOwnedPaths?: boolean;
 };
 
-export type Manifest = {
+export type SyncFsManifest = {
   share: string;
   entries: Record<string, FileInfoEntry | AbsenceEntry>;
 };

--- a/src/sync-fs/util.ts
+++ b/src/sync-fs/util.ts
@@ -1,10 +1,13 @@
 import { MANIFEST_FILE_NAME } from "./constants.ts";
-import { AbsenceEntry, FileInfoEntry, Manifest } from "./sync-fs-types.ts";
+import {
+  AbsenceEntry,
+  FileInfoEntry,
+  SyncFsManifest,
+} from "./sync-fs-types.ts";
 import {
   dirname,
   extname,
   join,
-  parse,
 } from "https://deno.land/std@0.132.0/path/mod.ts";
 import {
   decode,
@@ -51,10 +54,10 @@ export async function hasFilesButNoManifest(
   try {
     await Deno.stat(join(fsDirPath, MANIFEST_FILE_NAME));
 
-    // Manifest is present.
+    // SyncFsManifestis present.
     return false;
   } catch {
-    // Manifest is not present.
+    // SyncFsManifestis not present.
     const items = [];
     for await (const dirEntry of Deno.readDir(fsDirPath)) {
       items.push(dirEntry);
@@ -71,7 +74,7 @@ export async function dirBelongsToDifferentShare(
 ) {
   try {
     const contents = await Deno.readTextFile(join(dirPath, MANIFEST_FILE_NAME));
-    const manifest: Manifest = JSON.parse(contents);
+    const manifest: SyncFsManifest = JSON.parse(contents);
 
     return manifest.share !== shareAddress;
   } catch {
@@ -79,7 +82,7 @@ export async function dirBelongsToDifferentShare(
   }
 }
 
-export function writeManifest(manifest: Manifest, dirPath: string) {
+export function writeManifest(manifest: SyncFsManifest, dirPath: string) {
   return Deno.writeTextFile(
     join(dirPath, MANIFEST_FILE_NAME),
     JSON.stringify(manifest),
@@ -91,7 +94,7 @@ export async function getDirAssociatedShare(
 ) {
   try {
     const contents = await Deno.readTextFile(join(dirPath, MANIFEST_FILE_NAME));
-    const manifest: Manifest = JSON.parse(contents);
+    const manifest: SyncFsManifest = JSON.parse(contents);
 
     return manifest.share;
   } catch {

--- a/src/syncer/sync-coordinator.ts
+++ b/src/syncer/sync-coordinator.ts
@@ -150,7 +150,7 @@ export class SyncCoordinator {
       return;
     }
 
-    this.connection.notify(
+    await this.connection.notify(
       "notifyCaughtUpChange",
       mergedShareState.storageId,
       nextIsCaughtUp,

--- a/src/syncer/syncer.ts
+++ b/src/syncer/syncer.ts
@@ -44,14 +44,14 @@ export class Syncer<TransportType extends ITransport<SyncerBag>>
       this.coordinators.set(connection.description, coordinator);
       coordinator.start();
 
-      coordinator.syncStatuses.bus.on("*", () => {
+      coordinator.syncStatuses.bus.on("*", async () => {
         const syncStatuses: Record<ShareAddress, SyncSessionStatus> = {};
 
         for (const [share, status] of coordinator.syncStatuses.entries()) {
           syncStatuses[share] = status;
         }
 
-        this.syncStatuses.set(connection.description, syncStatuses);
+        await this.syncStatuses.set(connection.description, syncStatuses);
       });
     });
 

--- a/src/test/fs-sync/reconcile_manifest.test.ts
+++ b/src/test/fs-sync/reconcile_manifest.test.ts
@@ -7,7 +7,7 @@ import {
 } from "https://deno.land/std@0.132.0/testing/asserts.ts";
 import { MANIFEST_FILE_NAME } from "../../sync-fs/constants.ts";
 import { reconcileManifestWithDirContents } from "../../sync-fs/sync-fs.ts";
-import { FileInfoEntry, Manifest } from "../../sync-fs/sync-fs-types.ts";
+import { FileInfoEntry, SyncFsManifest } from "../../sync-fs/sync-fs-types.ts";
 import { isAbsenceEntry } from "../../sync-fs/util.ts";
 
 const TEST_DIR = "src/test/fs-sync/dirs/reconcile_manifest";
@@ -163,7 +163,7 @@ Deno.test("reconcileManifestWithDirContents", async (test) => {
   await emptyDir(TEST_DIR);
 });
 
-export function writeManifest(dirPath: string, manifest: Manifest) {
+export function writeManifest(dirPath: string, manifest: SyncFsManifest) {
   return Deno.writeTextFile(
     join(dirPath, MANIFEST_FILE_NAME),
     JSON.stringify(manifest),


### PR DESCRIPTION
## What's the problem you solved?

With the current implementation of `syncReplicaAndFsDir`, there are certain sequences of events that would cause errors about writing to unowned paths, even when the user hadn't done anything. For example:

```
0000: @aaaa sets /@aaaa/doc.txt to replica A .
0100: @bbbb syncs to replica B.
0150: @aaaa sets /@aaaa/doc.txt to replica A.
0200: @bbbb syncs to fs, writing /@aaaa.doc.txt (from 0000) to disk.
0300: @bbbb syncs replica B, getting latest doc written at 0150.
0400: @bbbb attempts sync to fs, but fails because their file (written  at 0200) has a newer timestamp and different hash to the doc set at @150 by @aaaa.
```

## What solution are you recommending?

I've added an option which forcibly overwrites files at paths not owned by the given identity.
