### PR TITLE
Add generateShareAddress utility, improve FS sync overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # next
 
+- Feature: Added `generateShareAddress` utility to generate valid, safe share
+  addresses.
 - Feature: Updated filesystem sync so that deleted (not just modified) files can
   be overwritten using the `overwriteFilesAtOwnedPaths` option.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+# next
+
+- Feature: Updated filesystem sync so that deleted (not just modified) files can
+  be overwritten using the `overwriteFilesAtOwnedPaths` option.
+
 # 9.1.0
 
-- Added 'overwriteFilesAtOwnedPaths' option to SyncFsOptions. This will forcibly
-  overwrite any files at paths owned by other identities with ones from the
-  replica.
+- Feature: Added 'overwriteFilesAtOwnedPaths' option to SyncFsOptions. This will
+  forcibly overwrite any files at paths owned by other identities with ones from
+  the replica.
 
 # 9.0.1
 

--- a/src/sync-fs/sync-fs.ts
+++ b/src/sync-fs/sync-fs.ts
@@ -233,7 +233,7 @@ export async function syncReplicaAndFsDir(
       const canWriteToPath = FormatValidatorEs4
         ._checkAuthorCanWriteToPath(opts.keypair.address, entry.path);
 
-      if (isErr(canWriteToPath)) {
+      if (isErr(canWriteToPath) && !opts.overwriteFilesAtOwnedPaths) {
         errors.push(canWriteToPath);
       }
     }

--- a/src/test/fs-sync/sync_share_dir.test.ts
+++ b/src/test/fs-sync/sync_share_dir.test.ts
@@ -232,7 +232,7 @@ Deno.test("syncShareAndDir", async (test) => {
       },
       undefined,
       `author ${keypairA.address} can't write to path`,
-      "trying to delete a file at someone's else's own path",
+      "trying to modify a file at someone's else's owned path",
     );
 
     await replica.set(keypairB, {
@@ -253,6 +253,38 @@ Deno.test("syncShareAndDir", async (test) => {
 
     assertEquals(
       ownedContents,
+      "Okay",
+      "File at owned path was forcibly overwritten.",
+    );
+
+    await Deno.remove(ownedPath);
+
+    await assertRejects(
+      () => {
+        return syncReplicaAndFsDir({
+          dirPath: TEST_DIR,
+          allowDirtyDirWithoutManifest: true,
+          keypair: keypairA,
+          replica,
+        });
+      },
+      undefined,
+      `author ${keypairA.address} can't write to path`,
+      "trying to delete a file at someone's else's owned path",
+    );
+
+    await syncReplicaAndFsDir({
+      dirPath: TEST_DIR,
+      allowDirtyDirWithoutManifest: true,
+      keypair: keypairA,
+      replica,
+      overwriteFilesAtOwnedPaths: true,
+    });
+
+    const ownedContents2 = await Deno.readTextFile(ownedPath);
+
+    assertEquals(
+      ownedContents2,
       "Okay",
       "File at owned path was forcibly overwritten.",
     );

--- a/src/test/universal/generate_share_address.test.ts
+++ b/src/test/universal/generate_share_address.test.ts
@@ -1,0 +1,20 @@
+import { assert, assertEquals } from "../asserts.ts";
+import { generateShareAddress } from "../../util/misc.ts";
+import { isErr } from "../../util/errors.ts";
+import { checkShareIsValid } from "../../core-validators/addresses.ts";
+
+Deno.test("generateShareAddress", () => {
+  const address = generateShareAddress("testing");
+  assert(!isErr(address), "address is valid (according to itself)");
+  assert(checkShareIsValid(address as string), "address is valid");
+  assert(
+    (address as string).startsWith("+testing."),
+    "address contains the given name",
+  );
+
+  const suffix = (address as string).split(".")[1];
+  assertEquals(suffix.length, 12, "suffix is 12 chars long");
+
+  const badAddress = generateShareAddress("FAILING_BAD");
+  assert(isErr(badAddress), "returns an error when given an invalid name");
+});

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -1,3 +1,10 @@
+import { checkShareIsValid } from "../core-validators/addresses.ts";
+import {
+  alphaLower,
+  workspaceKeyChars,
+} from "../core-validators/characters.ts";
+import { isErr, ValidationError } from "./errors.ts";
+
 export { fast_deep_equal as deepEqual } from "../../deps.ts";
 
 //================================================================================
@@ -35,4 +42,28 @@ export function countChars(str: string, char: string) {
 
 export function isObjectEmpty(obj: Object): Boolean {
   return Object.keys(obj).length === 0;
+}
+
+//================================================================================
+// Share
+
+export function generateShareAddress(name: string): string | ValidationError {
+  const randomFromString = (str: string) => {
+    return str[Math.floor(Math.random() * str.length)];
+  };
+
+  const firstLetter = randomFromString(alphaLower);
+  const rest = Array.from(Array(11), () => randomFromString(workspaceKeyChars))
+    .join("");
+
+  const suffix = `${firstLetter}${rest}`;
+  const address = `+${name}.${suffix}`;
+
+  const isValid = checkShareIsValid(address);
+
+  if (isErr(isValid)) {
+    return isValid;
+  }
+
+  return address;
 }


### PR DESCRIPTION
## What's the problem you solved?

- There was no easy way to generate share addresses.
- Even if you passed `overwriteFilesAtOwnedPaths: true` to syncReplicaAndFsDir, deleted files would continue to cause errors to throw.

## What solution are you recommending?

- Added a `generateShareAddress` utility, which takes a name as its sole argument.
- Made `AbsenceEntry`s also check for the presence of the `overwriteFilesAtOwnedPaths` option before throwing errors.