### PR TITLE
Permanently delete expired ephemeral docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,30 @@
-# 9.2.0
+# Changelog
+
+## next
+
+- Feature: Added `Replica.queryAuthors` and `Replica.queryPaths`, which returns
+  an array of (unique) authors of paths from the docs resulting from that query.
+
+## 9.2.0
 
 - Feature: Added `generateShareAddress` utility to generate valid, safe share
   addresses.
 - Feature: Updated filesystem sync so that deleted (not just modified) files can
   be overwritten using the `overwriteFilesAtOwnedPaths` option.
 
-# 9.1.0
+## 9.1.0
 
 - Feature: Added 'overwriteFilesAtOwnedPaths' option to SyncFsOptions. This will
   forcibly overwrite any files at paths owned by other identities with ones from
   the replica.
 
-# 9.0.1
+## 9.0.1
 
 - Added a `pulled` property to syncer statuses.
 - Fixed an issue where SyncCoordinators would pull twice as much as they needed
   to.
 
-# 9.0.0
+## 9.0.0
 
 - Breaking: Syncing has been updated so that peers inform each other when they
   are caught up. v7 - v8 peers will not be able to sync with each other.
@@ -39,14 +46,14 @@
   a file has changed or not, fixing issues where files at owned paths which had
   not been changed would cause the function to throw.
 
-# 8.3.1
+## 8.3.1
 
 - Patch: Made `syncReplicaAndFsDir` ignore `.DS_Store` files.
 - Patch: Improve how `syncReplicaAndFsDir` determines the latest version of a
   document, fixing an issue with 'zombie' files which would return after
   deletion.
 
-# 8.3.0
+## 8.3.0
 
 - Feature: Added a new export, `syncReplicaAndFsDir`, which bidirectionally
   syncs the contents of a replica and filesystem directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+- Feature: Replica will now permanently delete all expired documents on
+  instantiation, and delete expired docs every hour thereafter. Previously it
+  would only stop returning expired docs in user queries.
 - Feature: Added `Replica.queryAuthors` and `Replica.queryPaths`, which returns
   an array of (unique) authors of paths from the docs resulting from that query.
 

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -250,3 +250,14 @@ export function docMatchesFilter(doc: Doc, filter: QueryFilter): boolean {
   }
   return true;
 }
+
+/** Return whether a document is expired or not */
+export function docIsExpired(doc: Doc, now?: number) {
+  const nowToUse = now || Date.now() * 1000;
+
+  if (doc.deleteAfter === null) {
+    return false;
+  }
+
+  return nowToUse > doc.deleteAfter;
+}

--- a/src/replica/replica-driver-memory.ts
+++ b/src/replica/replica-driver-memory.ts
@@ -298,11 +298,14 @@ export class ReplicaDriverMemory implements IReplicaDriver {
       }
     }
 
+    const deletedPaths = new Set<Path>();
+
     for (const expiredDoc of expiredDocs) {
       this.docsByPathNewestFirst.delete(expiredDoc.path);
       this.docByPathAndAuthor.delete(combinePathAndAuthor(expiredDoc));
+      deletedPaths.add(expiredDoc.path);
     }
 
-    return Promise.resolve();
+    return Promise.resolve(Array.from(deletedPaths));
   }
 }

--- a/src/replica/replica-driver-memory.ts
+++ b/src/replica/replica-driver-memory.ts
@@ -9,7 +9,11 @@ import {
 } from "../util/errors.ts";
 
 import { compareArrays, compareByObjKey, sortedInPlace } from "./compare.ts";
-import { cleanUpQuery, docMatchesFilter } from "../query/query.ts";
+import {
+  cleanUpQuery,
+  docIsExpired,
+  docMatchesFilter,
+} from "../query/query.ts";
 
 //--------------------------------------------------
 
@@ -283,5 +287,22 @@ export class ReplicaDriverMemory implements IReplicaDriver {
     this.docsByPathNewestFirst.set(doc.path, docsByPath);
 
     return Promise.resolve(doc);
+  }
+
+  eraseExpiredDocs() {
+    const expiredDocs = [];
+
+    for (const [, doc] of this.docByPathAndAuthor) {
+      if (docIsExpired(doc)) {
+        expiredDocs.push(doc);
+      }
+    }
+
+    for (const expiredDoc of expiredDocs) {
+      this.docsByPathNewestFirst.delete(expiredDoc.path);
+      this.docByPathAndAuthor.delete(combinePathAndAuthor(expiredDoc));
+    }
+
+    return Promise.resolve();
   }
 }

--- a/src/replica/replica-driver-sqlite.deno.ts
+++ b/src/replica/replica-driver-sqlite.deno.ts
@@ -17,6 +17,7 @@ import {
   MAX_LOCAL_INDEX_QUERY,
   ReplicaSqliteOpts,
   SELECT_CONFIG_CONTENT_QUERY,
+  SELECT_EXPIRED_DOC_QUERY,
   SELECT_KEY_CONFIG_QUERY,
   SET_ENCODING_QUERY,
   UPSERT_CONFIG_QUERY,
@@ -408,9 +409,12 @@ export class ReplicaDriverSqlite implements IReplicaDriver {
       throw new ReplicaIsClosedError();
     }
 
-    this._db.query(DELETE_EXPIRED_DOC_QUERY, { now: Date.now() * 1000 });
+    const now = Date.now() * 1000;
 
-    return Promise.resolve();
+    const toDelete = this._db.query(SELECT_EXPIRED_DOC_QUERY, { now });
+    this._db.query(DELETE_EXPIRED_DOC_QUERY, { now });
+
+    return Promise.resolve(toDelete.map(([path]) => path as string));
   }
 
   //--------------------------------------------------

--- a/src/replica/replica-driver-sqlite.node.ts
+++ b/src/replica/replica-driver-sqlite.node.ts
@@ -16,6 +16,7 @@ import {
   CREATE_DOCS_TABLE_QUERY,
   CREATE_LOCAL_INDEX_INDEX_QUERY,
   DELETE_CONFIG_QUERY,
+  DELETE_EXPIRED_DOC_QUERY,
   makeDocQuerySql,
   MAX_LOCAL_INDEX_QUERY,
   ReplicaSqliteOpts,
@@ -331,6 +332,16 @@ export class ReplicaDriverSqlite implements IReplicaDriver {
     this._db.prepare(UPSERT_DOC_QUERY).run(docWithBuffer);
 
     return Promise.resolve(docWithLocalIndex);
+  }
+
+  eraseExpiredDocs() {
+    if (this._isClosed) {
+      throw new ReplicaIsClosedError();
+    }
+
+    this._db.prepare(DELETE_EXPIRED_DOC_QUERY).run({ now: Date.now() * 1000 });
+
+    return Promise.resolve();
   }
 
   //--------------------------------------------------

--- a/src/replica/replica-driver-sqlite.shared.ts
+++ b/src/replica/replica-driver-sqlite.shared.ts
@@ -45,6 +45,9 @@ export const UPSERT_DOC_QUERY =
   `INSERT OR REPLACE INTO docs (format, workspace, path, contentHash, content, author, timestamp, deleteAfter, signature, localIndex)
 VALUES (:format, :workspace, :path, :contentHash, :content, :author, :timestamp, :deleteAfter, :signature, :_localIndex);`;
 
+export const DELETE_EXPIRED_DOC_QUERY =
+  `DELETE FROM docs WHERE deleteAfter <= :now`;
+
 export const SET_ENCODING_QUERY = `PRAGMA encoding = "UTF-8";`;
 
 export const GET_ENCODING_QUERY = `PRAGMA encoding;`;

--- a/src/replica/replica-driver-sqlite.shared.ts
+++ b/src/replica/replica-driver-sqlite.shared.ts
@@ -45,6 +45,9 @@ export const UPSERT_DOC_QUERY =
   `INSERT OR REPLACE INTO docs (format, workspace, path, contentHash, content, author, timestamp, deleteAfter, signature, localIndex)
 VALUES (:format, :workspace, :path, :contentHash, :content, :author, :timestamp, :deleteAfter, :signature, :_localIndex);`;
 
+export const SELECT_EXPIRED_DOC_QUERY =
+  `SELECT path FROM docs WHERE deleteAfter <= :now`;
+
 export const DELETE_EXPIRED_DOC_QUERY =
   `DELETE FROM docs WHERE deleteAfter <= :now`;
 

--- a/src/replica/replica-types.ts
+++ b/src/replica/replica-types.ts
@@ -304,4 +304,7 @@ export interface IReplicaDriver extends IReplicaConfig {
   // overwrite existing doc even if this doc is older.
   // return a copy of the doc, frozen, with _localIndex set.
   upsert(doc: Doc): Promise<Doc>;
+
+  /** Erase all expired docs from the replica permanently, leaving no trace of the documents. */
+  eraseExpiredDocs(): Promise<void>;
 }

--- a/src/replica/replica-types.ts
+++ b/src/replica/replica-types.ts
@@ -20,7 +20,8 @@ export type ReplicaId = string;
 export type ReplicaBusChannel =
   | "ingest"
   | // 'write|/some/path.txt'  // note that write errors and no-ops are also sent here
-  "willClose"
+  "expire"
+  | "willClose"
   | "didClose";
 
 export interface QueryResult {
@@ -101,6 +102,11 @@ export interface IdleEvent {
   kind: "idle";
 }
 
+export interface ExpireEvent {
+  kind: "expire";
+  path: string;
+}
+
 /**
  * - IngestEventSuccess — a new doc was written
  * - IngestEventFailure — refused an invalid doc
@@ -126,7 +132,8 @@ export type LiveQueryEvent =
   | // waiting for an ingest to happen...
   IngestEvent
   | // an ingest happened
-  ReplicaEventWillClose
+  ExpireEvent
+  | ReplicaEventWillClose
   | ReplicaEventDidClose
   | QueryFollowerDidClose;
 
@@ -305,6 +312,6 @@ export interface IReplicaDriver extends IReplicaConfig {
   // return a copy of the doc, frozen, with _localIndex set.
   upsert(doc: Doc): Promise<Doc>;
 
-  /** Erase all expired docs from the replica permanently, leaving no trace of the documents. */
-  eraseExpiredDocs(): Promise<void>;
+  /** Erase all expired docs from the replica permanently, leaving no trace of the documents. Returns the paths of the expired documents. */
+  eraseExpiredDocs(): Promise<Path[]>;
 }

--- a/src/replica/replica-types.ts
+++ b/src/replica/replica-types.ts
@@ -1,4 +1,5 @@
 import {
+  AuthorAddress,
   AuthorKeypair,
   Doc,
   DocToSet,
@@ -226,8 +227,11 @@ export interface IReplica extends IReplicaConfig {
   */
   queryDocs(query?: Query): Promise<Doc[]>;
 
-  //    queryPaths(query?: Query): Path[];
-  //    queryAuthors(query?: Query): AuthorAddress[];
+  /** Returns an array of all unique paths of documents returned by a given query. */
+  queryPaths(query?: Query): Promise<Path[]>;
+
+  /** Returns an array of all unique authors of documents returned by a given query. */
+  queryAuthors(query?: Query): Promise<AuthorAddress[]>;
 
   //--------------------------------------------------
   // SET

--- a/src/replica/replica.ts
+++ b/src/replica/replica.ts
@@ -64,8 +64,9 @@ export class Replica implements IReplica {
   replicaDriver: IReplicaDriver;
   bus: Superbus<ReplicaBusChannel>;
 
-  _isClosed = false;
-  _ingestLock: Lock<IngestEvent>;
+  private _isClosed = false;
+  private ingestLock: Lock<IngestEvent>;
+  private eraseInterval: number;
 
   constructor(
     share: ShareAddress,
@@ -87,7 +88,17 @@ export class Replica implements IReplica {
     this.formatValidator = validator;
     this.replicaDriver = driver;
     this.bus = new Superbus<ReplicaBusChannel>("|");
-    this._ingestLock = new Lock<IngestEvent>();
+    this.ingestLock = new Lock<IngestEvent>();
+
+    this.eraseExpiredDocs();
+
+    this.eraseInterval = setInterval(() => {
+      if (!this.isClosed()) {
+        this.eraseExpiredDocs();
+      } else {
+        clearInterval(this.eraseInterval);
+      }
+    });
   }
 
   //--------------------------------------------------
@@ -116,6 +127,7 @@ export class Replica implements IReplica {
     logger.debug("    sending didClose nonblockingly...");
     await this.bus.sendAndWait("didClose");
     logger.debug("...closing done");
+    clearInterval(this.eraseInterval);
 
     return Promise.resolve();
   }
@@ -440,7 +452,7 @@ export class Replica implements IReplica {
     };
 
     loggerIngest.debug(" >> ingest: running protected region...");
-    let ingestEvent: IngestEvent = await this._ingestLock.run(
+    let ingestEvent: IngestEvent = await this.ingestLock.run(
       writeToDriverWithLock,
     );
     loggerIngest.debug(" >> ingest: ...done running protected region");
@@ -522,5 +534,16 @@ export class Replica implements IReplica {
       `    ...done; ${numOverwritten} overwritten to be empty; ${numAlreadyEmpty} were already empty; out of total ${docsToOverwrite.length} docs`,
     );
     return numOverwritten;
+  }
+
+  private async eraseExpiredDocs() {
+    const erasedPath = await this.replicaDriver.eraseExpiredDocs();
+
+    for (const path of erasedPath) {
+      await this.bus.sendAndWait(
+        `expire`,
+        path,
+      );
+    }
   }
 }

--- a/src/replica/replica.ts
+++ b/src/replica/replica.ts
@@ -1,6 +1,7 @@
 import { Lock, Superbus } from "../../deps.ts";
 import { Cmp } from "./util-types.ts";
 import {
+  AuthorAddress,
   AuthorKeypair,
   Doc,
   DocToSet,
@@ -227,8 +228,19 @@ export class Replica implements IReplica {
     return await this.replicaDriver.queryDocs(query);
   }
 
-  //queryPaths(query?: Query): Path[];
-  //queryAuthors(query?: Query): AuthorAddress[];
+  /** Returns an array of all unique paths of documents returned by a given query. */
+  async queryPaths(query?: Query) {
+    const docs = await this.queryDocs(query);
+    const pathsSet = new Set(docs.map(({ path }) => path));
+    return Array.from(pathsSet).sort();
+  }
+
+  /** Returns an array of all unique authors of documents returned by a given query. */
+  async queryAuthors(query?: Query) {
+    const docs = await this.queryDocs(query);
+    const authorsSet = new Set(docs.map(({ author }) => author));
+    return Array.from(authorsSet).sort();
+  }
 
   //--------------------------------------------------
   // SET

--- a/src/syncer/sync-coordinator.ts
+++ b/src/syncer/sync-coordinator.ts
@@ -69,7 +69,7 @@ export class SyncCoordinator {
     // Add a new sync status entry for each share
     for (const share of commonShares) {
       if (!this.syncStatuses.has(share)) {
-        await this.syncStatuses.set(share, {
+        this.syncStatuses.set(share, {
           ingestedCount: 0,
           pulledCount: 0,
           isCaughtUp: false,

--- a/src/test/improved/replica-driver.test.ts
+++ b/src/test/improved/replica-driver.test.ts
@@ -585,7 +585,9 @@ export function runReplicaDriverTests(scenario: TestScenario) {
       await test.step({
         name: "eraseExpiredDocs",
         fn: async () => {
-          await driver.eraseExpiredDocs();
+          const deletedPaths = await driver.eraseExpiredDocs();
+
+          assertEquals(deletedPaths, ["/posts/!post-0000.txt"]);
 
           const remainingEphemeralDocs = await driver.queryDocs({
             filter: {

--- a/src/test/improved/replica-driver.test.ts
+++ b/src/test/improved/replica-driver.test.ts
@@ -10,6 +10,8 @@ import { testScenarios } from "../test-scenarios.ts";
 //================================================================================
 
 import { LogLevel, setDefaultLogLevel } from "../../util/log.ts";
+import { sleep } from "../../util/misc.ts";
+import { isErr } from "../../util/errors.ts";
 //setDefaultLogLevel(LogLevel.Debug);
 let J = JSON.stringify;
 
@@ -525,6 +527,82 @@ export function runReplicaDriverTests(scenario: TestScenario) {
           (initialCryptoDriver as any).name
         }, ended as ${(GlobalCryptoDriver as any).name}`,
       );
+    },
+  );
+
+  Deno.test(
+    `${SUBTEST_NAME}: erasing expired docs`,
+    async (test) => {
+      const initialCryptoDriver = GlobalCryptoDriver;
+
+      const share = "+gardening.abcde";
+      const driver = scenario.makeDriver(share);
+
+      const now = Date.now() * 1000;
+
+      const expiredDoc0: Doc = {
+        format: "es.4",
+        author: "@suzy.bolxx3bc6gmoa43rr5qfgv6r65zbqjwtzcnr7zyef2hvpftw45clq",
+        content: "Hello 0",
+        contentHash: "bnkc2f3fbdfpfeanwcgbid4t2lanmtq2obsvijhsagmn3x652h57a",
+        deleteAfter: now + 1000,
+        path: "/posts/!post-0000.txt",
+        timestamp: now,
+        workspace: "+gardening.abc",
+        signature: "whatever0", // upsert does not check signature or validate doc
+      };
+
+      const expiredDoc1: Doc = {
+        format: "es.4",
+        author: "@suzy.bolxx3bc6gmoa43rr5qfgv6r65zbqjwtzcnr7zyef2hvpftw45clq",
+        content: "Hello 1",
+        contentHash: "bnkc2f3fbdfpfeanwcgbid4t2lanmtq2obsvijhsagmn3x652h57a",
+        deleteAfter: now + now, // Really far in the future.
+        path: "/posts/!post-0001.txt",
+        timestamp: now,
+        workspace: "+gardening.abc",
+        signature: "whatever0", // upsert does not check signature or validate doc
+      };
+
+      const normalDoc0: Doc = {
+        format: "es.4",
+        author: "@suzy.bolxx3bc6gmoa43rr5qfgv6r65zbqjwtzcnr7zyef2hvpftw45clq",
+        content: "Hello 1",
+        contentHash: "bnkc2f3fbdfpfeanwcgbid4t2lanmtq2obsvijhsagmn3x652h57a",
+        deleteAfter: null,
+        path: "/posts/post-0002.txt",
+        timestamp: now,
+        workspace: "+gardening.abc",
+        signature: "whatever0", // upsert does not check signature or validate doc
+      };
+
+      await driver.upsert(expiredDoc0);
+      await driver.upsert(expiredDoc1);
+      await driver.upsert(normalDoc0);
+
+      await sleep(100);
+
+      await test.step({
+        name: "eraseExpiredDocs",
+        fn: async () => {
+          await driver.eraseExpiredDocs();
+
+          const remainingEphemeralDocs = await driver.queryDocs({
+            filter: {
+              pathStartsWith: "/posts/",
+            },
+          });
+
+          assertEquals(remainingEphemeralDocs.map(({ path }) => path), [
+            "/posts/!post-0001.txt",
+            "/posts/post-0002.txt",
+          ], "only the non-expired ephemeral doc remains");
+        },
+        sanitizeOps: false,
+        sanitizeResources: false,
+      });
+
+      await driver.close(true);
     },
   );
 }

--- a/src/test/universal/replica-cache.test.ts
+++ b/src/test/universal/replica-cache.test.ts
@@ -191,4 +191,6 @@ Deno.test("ReplicaCache", async () => {
     1,
     "Quickly expiring cache was updated once, even after second request",
   );
+
+  await storage.close(true);
 });

--- a/src/test/universal/sync-coordinator.test.ts
+++ b/src/test/universal/sync-coordinator.test.ts
@@ -189,6 +189,20 @@ Deno.test("SyncCoordinator", async () => {
 
   // Close up
 
+  for (
+    const replica of [
+      storageA1,
+      storageA2,
+      storageB1,
+      storageC1,
+      storageC2,
+      storageD1,
+      storageD2,
+    ]
+  ) {
+    await replica.close(true);
+  }
+
   coordinator.close();
   localTransport.close();
   targetTransport.close();


### PR DESCRIPTION
## What's the problem you solved?

@AnActualEmerald reported to me that they found expired docs remained in storage, even though they were not being returned in results. This is obviously not what we want.

## What solution are you recommending?

Replicas will now permanently delete all expired docs on instantiation, and thereafter every hour. Later on I will make it so that documents are erased on their actual expiry timestamp.