### PR TITLE
Remove crayon/chalk dependency

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,3 @@
-export { default as chalk } from "https://deno.land/x/crayon_chalk_aliases@1.1.0/index.ts";
 export { default as fast_deep_equal } from "https://esm.sh/fast-deep-equal@3.1.3";
 export { default as cloneDeep } from "https://deno.land/x/denodash@v0.1.3/src/lang/cloneDeep.ts";
 export { default as fast_json_stable_stringify } from "https://esm.sh/fast-json-stable-stringify@2.1.0";

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -38,10 +38,6 @@ await build({
       name: "express",
       version: "4.17.2",
     },
-    "https://deno.land/x/crayon_chalk_aliases@1.1.0/index.ts": {
-      name: "chalk",
-      version: "4.1.2",
-    },
     "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts": {
       name: "concurrency-friends",
       version: "5.2.0",

--- a/src/crypto/crypto.ts
+++ b/src/crypto/crypto.ts
@@ -20,7 +20,7 @@ import { GlobalCryptoDriver } from "./global-crypto-driver.ts";
 //--------------------------------------------------
 
 import { Logger } from "../util/log.ts";
-let logger = new Logger("crypto", "cyanBright");
+let logger = new Logger("crypto", "cyan");
 
 //================================================================================
 

--- a/src/crypto/global-crypto-driver.ts
+++ b/src/crypto/global-crypto-driver.ts
@@ -4,7 +4,7 @@ import { ICryptoDriver } from "./crypto-types.ts";
 //--------------------------------------------------
 
 import { Logger } from "../util/log.ts";
-let logger = new Logger("crypto", "cyanBright");
+let logger = new Logger("crypto", "cyan");
 
 //================================================================================
 

--- a/src/peer/peer.ts
+++ b/src/peer/peer.ts
@@ -18,7 +18,8 @@ import { randomId } from "../util/misc.ts";
 
 import { Logger } from "../util/log.ts";
 import { SyncSessionStatus } from "../syncer/syncer-types.ts";
-const logger = new Logger("peer", "blueBright");
+const logger = new Logger("peer", "orangeRed");
+
 const J = JSON.stringify;
 
 //================================================================================

--- a/src/query-follower/query-follower.ts
+++ b/src/query-follower/query-follower.ts
@@ -25,7 +25,7 @@ import {
   setLogLevel,
 } from "../util/log.ts";
 import { sleep } from "../util/misc.ts";
-let logger = new Logger("QueryFollower", "redBright");
+let logger = new Logger("QueryFollower", "red");
 let loggerSub = new Logger("QueryFollowerSub", "red");
 let J = JSON.stringify;
 

--- a/src/query/query-helpers.ts
+++ b/src/query/query-helpers.ts
@@ -5,7 +5,7 @@ import { Query, QueryFilter } from "../query/query-types.ts";
 import { countChars, isObjectEmpty, replaceAll } from "../util/misc.ts";
 import { Logger, LogLevel, setLogLevel } from "../util/log.ts";
 
-let logger = new Logger("query helpers", "yellowBright");
+let logger = new Logger("query helpers", "gold");
 
 //================================================================================
 // HELPERS

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -7,7 +7,7 @@ import { stringLengthInBytes } from "../util/bytes.ts";
 //--------------------------------------------------
 
 import { Logger } from "../util/log.ts";
-const logger = new Logger("query", "greenBright");
+const logger = new Logger("query", "green");
 
 //================================================================================
 

--- a/src/replica/replica-driver-indexeddb.ts
+++ b/src/replica/replica-driver-indexeddb.ts
@@ -8,7 +8,8 @@ import { Query } from "../query/query-types.ts";
 //--------------------------------------------------
 
 import { Logger } from "../util/log.ts";
-const logger = new Logger("replica driver indexeddb", "yellowBright");
+
+const logger = new Logger("replica driver indexeddb", "gold");
 
 //================================================================================
 
@@ -90,7 +91,7 @@ export class ReplicaDriverIndexedDB extends ReplicaDriverMemory {
           );
 
           const localIndexes = Array.from(this.docByPathAndAuthor.values()).map(
-            (doc) => doc._localIndex as number
+            (doc) => doc._localIndex as number,
           );
           this._maxLocalIndex = Math.max(...localIndexes);
 

--- a/src/replica/replica-driver-local-storage.ts
+++ b/src/replica/replica-driver-local-storage.ts
@@ -6,7 +6,7 @@ import { ReplicaDriverMemory } from "./replica-driver-memory.ts";
 
 import { Logger } from "../util/log.ts";
 import { checkShareIsValid } from "../core-validators/addresses.ts";
-let logger = new Logger("storage driver localStorage", "yellowBright");
+let logger = new Logger("storage driver localStorage", "gold");
 
 //================================================================================
 type SerializedDriverDocs = {

--- a/src/replica/replica.ts
+++ b/src/replica/replica.ts
@@ -33,9 +33,9 @@ import { Crypto } from "../crypto/crypto.ts";
 
 import { Logger } from "../util/log.ts";
 const J = JSON.stringify;
-const logger = new Logger("replica", "yellowBright");
-const loggerSet = new Logger("replica set", "yellowBright");
-const loggerIngest = new Logger("replica ingest", "yellowBright");
+const logger = new Logger("replica", "gold");
+const loggerSet = new Logger("replica set", "gold");
+const loggerIngest = new Logger("replica ingest", "gold");
 
 //================================================================================
 

--- a/src/test/improved/query-follower.test.ts
+++ b/src/test/improved/query-follower.test.ts
@@ -16,8 +16,8 @@ import { testScenarios } from "../test-scenarios.ts";
 
 import { Logger, LogLevel, setLogLevel } from "../../util/log.ts";
 import { QueryFollower } from "../../query-follower/query-follower.ts";
-let loggerTest = new Logger("test", "whiteBright");
-let loggerTestCb = new Logger("test cb", "white");
+let loggerTest = new Logger("test", "salmon");
+let loggerTestCb = new Logger("test cb", "lightsalmon");
 let J = JSON.stringify;
 
 //setLogLevel('test', LogLevel.Debug);

--- a/src/test/improved/query-helpers.test.ts
+++ b/src/test/improved/query-helpers.test.ts
@@ -42,7 +42,7 @@ let runQueryHelpersTests = async (
     return new Replica(ws, FormatValidatorEs4, driver);
   }
 
-  let logger = new Logger("query helpers test", "yellowBright");
+  let logger = new Logger("query helpers test", "yellow");
 
   //================================================================================
   // HELPERS

--- a/src/test/improved/replica.test.ts
+++ b/src/test/improved/replica.test.ts
@@ -15,8 +15,8 @@ import { testScenarios } from "../test-scenarios.ts";
 //================================================================================
 
 import { Logger } from "../../util/log.ts";
-const loggerTest = new Logger("test", "whiteBright");
-const loggerTestCb = new Logger("test cb", "white");
+const loggerTest = new Logger("test", "salmon");
+const loggerTestCb = new Logger("test cb", "lightsalmon");
 //setLogLevel('test', LogLevel.Debug);
 
 //================================================================================

--- a/src/test/improved/storage-config.test.ts
+++ b/src/test/improved/storage-config.test.ts
@@ -17,8 +17,8 @@ import { testScenarios } from "../test-scenarios.ts";
 //================================================================================
 
 import { Logger, LogLevel, setLogLevel } from "../../util/log.ts";
-let loggerTest = new Logger("test", "whiteBright");
-let loggerTestCb = new Logger("test cb", "white");
+let loggerTest = new Logger("test", "lightsalmon");
+let loggerTestCb = new Logger("test cb", "salmon");
 let J = JSON.stringify;
 //setLogLevel('test', LogLevel.Debug);
 

--- a/src/test/original/peer.test.ts
+++ b/src/test/original/peer.test.ts
@@ -14,8 +14,8 @@ import { TestScenario } from "../test-scenario-types.ts";
 
 import { Logger } from "../../util/log.ts";
 
-const loggerTest = new Logger("test", "whiteBright");
-const loggerTestCb = new Logger("test cb", "white");
+const loggerTest = new Logger("test", "lightsalmon");
+const loggerTestCb = new Logger("test cb", "salmon");
 const J = JSON.stringify;
 
 //setDefaultLogLevel(LogLevel.None);

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -24,8 +24,6 @@
  * The environment variable wins over the numbers set by setLogLevels.
  */
 
-import { chalk } from "../../deps.ts";
-
 //================================================================================
 // TYPES
 
@@ -101,43 +99,45 @@ export function getLogLevels(): LogLevels {
 //================================================================================
 // Logger class
 
-type ChalkColor =
+type LogColor =
   | "blue"
-  | "blueBright"
-  | "bold"
+  | "aqua"
+  | "darkcyan"
   | "cyan"
-  | "cyanBright"
-  | "dim"
-  | "gray"
+  | "dimgray"
+  | "slategray"
   | "green"
-  | "greenBright"
+  | "springgreen"
   | "grey"
+  | "darkMagenta"
   | "magenta"
-  | "magentaBright"
   | "red"
-  | "redBright"
-  | "white"
-  | "whiteBright"
-  | "yellow"
-  | "yellowBright";
+  | "orangeRed"
+  | "salmon"
+  | "lightsalmon"
+  | "gold"
+  | "yellow";
 
 export class Logger {
   source: LogSource;
-  color: ChalkColor | undefined = undefined;
+  color: LogColor | undefined = undefined;
 
-  constructor(source: LogSource, color?: ChalkColor) {
+  constructor(source: LogSource, color?: LogColor) {
     this.source = source;
-    this.color = color || "blueBright";
+    this.color = color || "aqua";
   }
 
   _print(level: LogLevel, showTag: boolean, indent: string, ...args: any[]) {
     if (level <= getLogLevel(this.source)) {
       if (showTag) {
-        let tag = `[${this.source}]`;
+        const tag = `[${this.source}]`;
+
         if (this.color !== undefined) {
-          tag = (chalk as any)[this.color](tag);
+          const tagArgs = [`%c ${tag}`, `color: ${this.color}`];
+          console.log(indent, ...tagArgs, ...args);
+        } else {
+          console.log(indent, tag, ...args);
         }
-        console.log(indent, tag, ...args);
       } else {
         console.log(indent, ...args);
       }


### PR DESCRIPTION
## What's the problem you solved?

crayon was internally using an unpinned dependency for chalk which has broken v9.2.4. Great argument for vendoring our dependencies.

## What solution are you recommending?

This PR removes `chalk` entirely in favour of the standard API for colouring console.log statements.

Fixes #258 
