### PR TITLE
Update sqlite3 to use auto-installing sqlite feature

### DIFF
--- a/src/replica/doc_drivers/sqlite_ffi.ts
+++ b/src/replica/doc_drivers/sqlite_ffi.ts
@@ -22,7 +22,7 @@ import {
   UPSERT_CONFIG_QUERY,
   UPSERT_DOC_QUERY,
 } from "./sqlite.shared.ts";
-import * as Sqlite from "https://deno.land/x/sqlite3@0.5.2/mod.ts";
+import * as Sqlite from "https://deno.land/x/sqlite3@0.5.3/mod.ts";
 
 //--------------------------------------------------
 


### PR DESCRIPTION
Update sqlite3 dependency to take advantage of a feature which installs sqlite3 for you (very helpful for servers)