### PR TITLE
Fix issue causing peers to think they're in sync

### DIFF
--- a/src/syncer/have_entry_keeper.ts
+++ b/src/syncer/have_entry_keeper.ts
@@ -244,10 +244,12 @@ export class HaveEntryKeeper {
         return aId < bId ? -1 : 1;
       },
     ).map(([id, entry]) => {
-      const versionStrings = [];
+      const versionStrings: string[] = [];
 
       for (const key in entry.versions) {
-        versionStrings.push(key);
+        const v = entry.versions[key];
+
+        versionStrings.push(`${v.author}_${v.timestamp}`);
       }
 
       return `${id}:${versionStrings.join(",")}`;


### PR DESCRIPTION
## What's the problem you solved?

The way hashes were being calculated by HaveEntryKeeper only took into account the path and author, and not the timestamp, meaning that two peers could think they were in sync when they weren't.

## What solution are you recommending?

Include the timestamp in how the hash is calculated.