### PR TITLE
Deno version warning

### DIFF
--- a/.github/workflows/deno.js.yml
+++ b/.github/workflows/deno.js.yml
@@ -2,9 +2,9 @@ name: Deno CI
 
 on:
   push:
-    branches: [main, squirrel]
+    branches: [main]
   pull_request:
-    branches: [main, squirrel]
+    branches: [main]
 
 jobs:
   build:
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: ["1.25.1"]
+        deno-version: ["1.29.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Or Deno:
 import * as Earthstar from "https://deno.land/x/earthstar@v10.0.0/mod.ts";`}
 ```
 
-> Earthstar's syncing does not work with version of Deno between 1.27.0 - 1.28.1
+> Earthstar's syncing does not work with version of Deno between 1.27.0 - 1.28.3
 > (inclusive) due to a regression in these versions' WebSocket implementation.
+> **Use Deno 1.29.0 or higher.**
 
 or installed with NPM:
 

--- a/src/replica/attachment_drivers/filesystem.ts
+++ b/src/replica/attachment_drivers/filesystem.ts
@@ -77,7 +77,10 @@ export class AttachmentDriverFilesystem implements IReplicaAttachmentDriver {
     }
 
     try {
-      const file = await Deno.open(stagingPath, { create: true, write: true });
+      const file = await Deno.open(stagingPath, {
+        createNew: true,
+        write: true,
+      });
       await attachment.pipeThrough(attachmentStreamInfo).pipeTo(file.writable);
     } catch {
       return new EarthstarError("Couldn't write data to the staging path");

--- a/src/sync-fs/util.ts
+++ b/src/sync-fs/util.ts
@@ -196,7 +196,11 @@ export async function writeDocToDir(
     }
 
     try {
-      const file = await Deno.open(pathToWrite, { create: true, write: true });
+      const file = await Deno.open(pathToWrite, {
+        create: true,
+        write: true,
+        truncate: true,
+      });
       await (await attachment.stream()).pipeTo(file.writable);
     } catch {
       throw new EarthstarError("Could not write attachment to filesystem");

--- a/src/syncer/transfer_manager.ts
+++ b/src/syncer/transfer_manager.ts
@@ -85,7 +85,7 @@ export class TransferManager<FormatsType, IncomingAttachmentSourceType> {
             const res = await agent.replica.getAttachment(event.doc, format);
 
             if (isErr(res)) {
-              // This doc can't have a attachment attached. Do nothing.
+              // This doc can't have an attachment attached. Do nothing.
               return;
             } else if (res === undefined) {
               await handleDownload(


### PR DESCRIPTION
## What's the problem you solved?

Certain attachment transfers were not working during sync. Investigation showed that this was due to Deno's websocket implementation.

## What solution are you recommending?

Recommend users use Deno 1.29.0 and up.