### PR TITLE
Improve web sync errors thrown from WebSockets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## NEXT
+
+- (Improvement) - Better error messages for web syncing failures (e.g. 404,
+  wrong endpoint).
+
 ## v10.0.0
 
 This is a major release which introduces attachments, share keypairs, efficient

--- a/src/syncer/partner_web_client.ts
+++ b/src/syncer/partner_web_client.ts
@@ -57,8 +57,14 @@ export class PartnerWebClient<
       this.incomingQueue.close();
     };
 
-    this.socket.onerror = (err) => {
-      console.error(err);
+    this.socket.onerror = (event) => {
+      if ("error" in event) {
+        this.incomingQueue.close({
+          withError: event.error,
+        });
+
+        return;
+      }
 
       this.incomingQueue.close({
         withError: new EarthstarError("Websocket error."),

--- a/src/syncer/partner_web_server.ts
+++ b/src/syncer/partner_web_server.ts
@@ -72,7 +72,15 @@ export class PartnerWebServer<
       this.incomingQueue.close();
     };
 
-    this.socket.onerror = () => {
+    this.socket.onerror = (event) => {
+      if ("error" in event) {
+        this.incomingQueue.close({
+          withError: event.error,
+        });
+
+        return;
+      }
+
       this.incomingQueue.close({
         withError: new EarthstarError("Websocket error."),
       });


### PR DESCRIPTION
## What's the problem you solved?

If a failure occurred during sync over HTTP, the user would only get an uninformative 'Websocket error' message. Even for commonplace failures like the server not being reachable, or the endpoint not being valid.

## What solution are you recommending?

I'm now passing the original errors along, so users get more useful messages like `DOMException: failed to connect to WebSocket: HTTP error: 404 Not Found`.
