### PR TITLE
Improve error reporting during sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT
+
+- Warn in the console when a replica could not ingest an attachment during sync.
+
 ## v10.0.0
 
 This is a major release which introduces attachments, share keypairs, efficient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## NEXT
 
-- Warn in the console when a replica could not ingest an attachment during sync.
+- (Improvement) - Warn in the console when a replica could not ingest an
+  attachment during sync.
+- (Improvement) - Better error messages for web syncing failures (e.g. 404,
+  wrong endpoint).
 
 ## v10.0.0
 

--- a/src/syncer/attachment_transfer.ts
+++ b/src/syncer/attachment_transfer.ts
@@ -100,6 +100,10 @@ export class AttachmentTransfer<F> {
               }
 
               if (isErr(result)) {
+                console.warn(
+                  `Couldn't ingest the attachment for ${doc.path} by ${doc.author}: ${result.message}`,
+                );
+
                 promise.reject(result);
                 return;
               }

--- a/src/syncer/partner_web_client.ts
+++ b/src/syncer/partner_web_client.ts
@@ -57,8 +57,14 @@ export class PartnerWebClient<
       this.incomingQueue.close();
     };
 
-    this.socket.onerror = (err) => {
-      console.error(err);
+    this.socket.onerror = (event) => {
+      if ("error" in event) {
+        this.incomingQueue.close({
+          withError: event.error,
+        });
+
+        return;
+      }
 
       this.incomingQueue.close({
         withError: new EarthstarError("Websocket error."),

--- a/src/syncer/partner_web_server.ts
+++ b/src/syncer/partner_web_server.ts
@@ -72,7 +72,15 @@ export class PartnerWebServer<
       this.incomingQueue.close();
     };
 
-    this.socket.onerror = () => {
+    this.socket.onerror = (event) => {
+      if ("error" in event) {
+        this.incomingQueue.close({
+          withError: event.error,
+        });
+
+        return;
+      }
+
       this.incomingQueue.close({
         withError: new EarthstarError("Websocket error."),
       });


### PR DESCRIPTION
## What's the problem you solved?

- Vague errors when the WebSockets API threw an error
- Not knowing why attachments did not sync

## What solution are you recommending?

- More specific error messages for WebSocket API failures
- Logging warnings when a transferred attachment could not be ingested.