### PR TITLE
Add syncing timeouts, more test parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NEXT
 
+- (Improvement) - Syncer will cancel itself if it does not receive anything from
+  the other peer within a ten second window.
+- (Improvement) - Syncer will cancel an attachment transfer if it doesn't
+  receive anything from the other side within a ten second window.
 - (Improvement) - Warn in the console when a replica could not ingest an
   attachment during sync.
 - (Improvement) - Better error messages for web syncing failures (e.g. 404,

--- a/src/syncer/bumping_timeout.ts
+++ b/src/syncer/bumping_timeout.ts
@@ -1,0 +1,29 @@
+
+/** A timeout which can be 'bumped' manually, restarting the timer. */
+export class BumpingTimeout {
+	private timeout: number;
+	private cb: () => void;
+	private ms: number;
+	private closed = false;
+
+	constructor(cb: () => void, ms: number) {
+		this.cb = cb;
+		this.ms = ms;
+		this.timeout = setTimeout(cb, ms);
+	}
+
+	bump() {
+		if (this.closed) {
+			return;
+		}
+
+		clearTimeout(this.timeout);
+		this.timeout = setTimeout(this.cb, this.ms);
+	}
+
+	close() {
+		this.closed = true;
+
+		clearTimeout(this.timeout);
+	}
+}

--- a/src/syncer/constants.ts
+++ b/src/syncer/constants.ts
@@ -1,0 +1,3 @@
+// Research indicates 10 seconds is the limit for holding someone's attention without any kind of feedback.
+/** The maximum number of milliseconds to wait for some kind of communication from the other peer. */
+export const TIMEOUT_MS = 10000;

--- a/src/test/syncer/syncer.test.ts
+++ b/src/test/syncer/syncer.test.ts
@@ -50,6 +50,153 @@ const scenarios: MultiplyScenarioOutput<{
   scenarios: setOverlap,
 });
 
+Deno.test("Sync a single document", async (test) => {
+  const authorKeypair = await Crypto.generateAuthorKeypair(
+    "test",
+  ) as AuthorKeypair;
+
+  const shareKeypair = await Crypto.generateShareKeypair(
+    "apples",
+  ) as ShareKeypair;
+
+  for (const driverScenario of syncDriverScenarios) {
+    await test.step({
+      name: `Finishes and syncs (${driverScenario.name})`,
+      fn: async () => {
+        const replicaA = new Replica({
+          driver: new ReplicaDriverMemory(shareKeypair.shareAddress),
+          shareSecret: shareKeypair.secret,
+        });
+
+        const replicaB = new Replica({
+          driver: new ReplicaDriverMemory(shareKeypair.shareAddress),
+          shareSecret: shareKeypair.secret,
+        });
+
+        await replicaA.set(authorKeypair, {
+          path: "/test/path",
+          text: "Hello",
+        });
+
+        const peerA = new Peer();
+        peerA.addReplica(replicaA);
+
+        const peerB = new Peer();
+        peerB.addReplica(replicaB);
+
+        const syncDriverScenario = driverScenario.item(
+          [FormatEs5],
+          "once",
+        );
+
+        // Initiate sync for each peer using the driver.
+        const [syncerA, syncerB] = await syncDriverScenario.setup(peerA, peerB);
+
+        // Check that the sync finishes.
+        await Promise.all([syncerA.isDone(), syncerB.isDone()]);
+
+        // Check that all replicas fully synced.
+
+        await syncDriverScenario.teardown();
+
+        assert(
+          await replicaDocsAreSynced([replicaA, replicaB]),
+          `+a docs are in sync`,
+        );
+
+        assert(
+          await replicaAttachmentsAreSynced([replicaA, replicaB]),
+          `+a attachments are in sync`,
+        );
+
+        await replicaA.close(true);
+        await replicaB.close(true);
+      },
+    });
+  }
+});
+
+Deno.test("Sync a single document (with attachment)", async (test) => {
+  const authorKeypair = await Crypto.generateAuthorKeypair(
+    "test",
+  ) as AuthorKeypair;
+
+  const shareKeypair = await Crypto.generateShareKeypair(
+    "apples",
+  ) as ShareKeypair;
+
+  for (const driverScenario of syncDriverScenarios) {
+    await test.step({
+      name: `Finishes and syncs (${driverScenario.name})`,
+      fn: async () => {
+        const replicaA = new Replica({
+          driver: new ReplicaDriverMemory(shareKeypair.shareAddress),
+          shareSecret: shareKeypair.secret,
+        });
+
+        const replicaB = new Replica({
+          driver: new ReplicaDriverMemory(shareKeypair.shareAddress),
+          shareSecret: shareKeypair.secret,
+        });
+
+        const randomBytes = crypto.getRandomValues(
+          new Uint8Array(32 * 32 * 32),
+        );
+
+        const multiplicationFactor = 32;
+
+        const bytes = new Uint8Array(
+          randomBytes.length * multiplicationFactor,
+        );
+
+        for (let i = 0; i < multiplicationFactor - 1; i++) {
+          bytes.set(randomBytes, i * randomBytes.length);
+        }
+
+        await replicaA.set(authorKeypair, {
+          path: "/test/path.txt",
+          text: "Hello",
+          attachment: bytes,
+        });
+
+        const peerA = new Peer();
+        peerA.addReplica(replicaA);
+
+        const peerB = new Peer();
+        peerB.addReplica(replicaB);
+
+        const syncDriverScenario = driverScenario.item(
+          [FormatEs5],
+          "once",
+        );
+
+        // Initiate sync for each peer using the driver.
+        const [syncerA, syncerB] = await syncDriverScenario.setup(peerA, peerB);
+
+        // Check that the sync finishes.
+        await Promise.all([syncerA.isDone(), syncerB.isDone()]);
+
+        // Check that all replicas fully synced.
+
+        await syncDriverScenario.teardown();
+
+        assert(
+          await replicaDocsAreSynced([replicaA, replicaB]),
+          `+a docs are in sync`,
+        );
+
+        assert(
+          await replicaAttachmentsAreSynced([replicaA, replicaB]),
+          `+a attachments are in sync`,
+        );
+
+        await replicaA.close(true);
+        await replicaB.close(true);
+      },
+    });
+  }
+});
+
 Deno.test("Syncing (appetite 'once')", async (test) => {
   const authorKeypair = await Crypto.generateAuthorKeypair(
     "test",

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -162,15 +162,25 @@ export function writeRandomDocs(
 ) {
   const fstRand = randomId();
 
-  const hasAttachment = Math.random() >= 0.8;
+  const hasAttachment = Math.random() >= 0.5;
 
   const setPromises = Array.from({ length: n }, () => {
     const rand = randomId();
 
     if (hasAttachment) {
-      const bytes = crypto.getRandomValues(
+      const randomBytes = crypto.getRandomValues(
         new Uint8Array((Math.random() + 0.1) * 32 * 32 * 32),
       );
+
+      const multiplicationFactor = Math.random() * 32;
+
+      const bytes = new Uint8Array(
+        randomBytes.length * multiplicationFactor,
+      );
+
+      for (let i = 0; i < multiplicationFactor - 1; i++) {
+        bytes.set(randomBytes, i * randomBytes.length);
+      }
 
       return storage.set(keypair, {
         text: `${rand}`,


### PR DESCRIPTION
## What's the problem you solved?

- Syncing could hang indefinitely if the other side sent no messages during sync or attachment transfer.

## What solution are you recommending?

- Added a timeout for receiving new messages from the other side, both for overall syncing and individual attachment transfers.
- Also added more tests (for syncing single items, and larger attachments)