### PR TITLE
Update CI and README with Deno 1.30

### DIFF
--- a/.github/workflows/deno.js.yml
+++ b/.github/workflows/deno.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: ["1.26.2"]
+        deno-version: ["1.30.0"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import * as Earthstar from "https://deno.land/x/earthstar/mod.ts";`}
 
 > Earthstar's web syncing does not work with version of Deno between 1.27.0 -
 > 1.29.3 (inclusive) due to a regression in these versions' WebSocket
-> implementation. **Use Deno 1.26.2.**
+> implementation. **Use Deno 1.30.0. or later**, or Deno 1.26.2.
 
 or installed with NPM:
 

--- a/README_SERVERS.md
+++ b/README_SERVERS.md
@@ -222,7 +222,7 @@ host with a `known_share.json` and persists share data to a directory called
 `data`:
 
 ```docker
-FROM denoland/deno:1.29.1
+FROM denoland/deno:1.30.0
 
 EXPOSE 8080
 EXPOSE 443


### PR DESCRIPTION
## What's the problem you solved?

We had to tell users to avoid the latest versions of Deno in order for sync to work.

## What solution are you recommending?

Deno 1.30.0 fixed this issue .

Closes #297 