### PR TITLE
Update Sqlite FFI Doc Driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## NEXT
+
+- (Fix) `DocDriverSqliteFfi` has been updated to use
+  `https://deno.land/x/sqlite3@0.7.3` which has compatibility with Deno 1.30.0.
+  This driver uses unstable APIs and will not work with previous versions of
+  Deno.
+
 ## v10.0.1
 
 This is a patch release focused on resolving errors encountered during syncing,

--- a/src/test/scenarios/scenarios.ts
+++ b/src/test/scenarios/scenarios.ts
@@ -54,7 +54,6 @@ export const docDriverScenarios: Scenario<DocDriverScenario>[] = [
         new DocDriverLocalStorage(addr, variant),
     },
   },
-  /* TODO: Re-add to tests when we're no longer stuck on Deno 1.26.2
   {
     name: "Sqlite FFI",
     item: {
@@ -68,7 +67,6 @@ export const docDriverScenarios: Scenario<DocDriverScenario>[] = [
         }),
     },
   },
-  */
   {
     name: "Sqlite",
     item: {


### PR DESCRIPTION
## What's the problem you solved?

The unstable `DocDriverSqliteFfi` driver did not work with Deno 1.30.

## What solution are you recommending?

Updated  `DocDriverSqliteFfi` to use the latest version of `x/sqlite3`, which has compatibility with Deno 1.30.

Also re-enabled this driver's usage in testing.