### PR TITLE
Updated range-reconcile v1.0.1

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -10,11 +10,12 @@ export { hash as xxhash64, XXH64 } from "./src/util/xxhash64.js";
 export {
   FingerprintTree,
   RangeMessenger,
-} from "https://deno.land/x/range_reconcile@0.1.2/mod.ts";
+} from "https://deno.land/x/range_reconcile@1.0.1/mod.ts";
 export type {
   LiftingMonoid,
   RangeMessengerConfig,
-} from "https://deno.land/x/range_reconcile@0.1.2/mod.ts";
+} from "https://deno.land/x/range_reconcile@1.0.1/mod.ts";
+
 export { AsyncQueue } from "https://deno.land/x/for_awaitable_queue@1.0.0/mod.ts";
 
 // Deno std lib

--- a/src/replica/doc_drivers/sqlite_ffi.ts
+++ b/src/replica/doc_drivers/sqlite_ffi.ts
@@ -172,8 +172,6 @@ export class DocDriverSqliteFfi implements IReplicaDocDriver {
       { "MAX(localIndex)": number | null }
     >();
 
-    console.log(maxLocalIndexResult);
-
     const maxLocalIndex = maxLocalIndexResult
       ? maxLocalIndexResult["MAX(localIndex)"]
       : -1;

--- a/src/syncer/range_messenger.ts
+++ b/src/syncer/range_messenger.ts
@@ -3,6 +3,16 @@ import { bigIntFromHex, bigIntToHex } from "../util/bigint.ts";
 import { DocThumbnailTree } from "./doc_thumbnail_tree.ts";
 import { DocThumbnail, RangeMessage } from "./syncer_types.ts";
 
+const TYPE_MAPPINGS = {
+  "EMPTY_SET": "emptySet" as const,
+  "LOWER_BOUND": "lowerBound" as const,
+  "PAYLOAD": "payload" as const,
+  "EMPTY_PAYLOAD": "emptyPayload" as const,
+  "DONE": "done" as const,
+  "FINGERPRINT": "fingerprint" as const,
+  "TERMINAL": "terminal" as const,
+};
+
 const encoding: RangeMessengerConfig<
   RangeMessage,
   DocThumbnail,
@@ -40,6 +50,9 @@ const encoding: RangeMessengerConfig<
     }),
   },
   decode: {
+    getType: (obj) => {
+      return TYPE_MAPPINGS[obj.type];
+    },
     emptySet: (obj) => {
       if (obj.type === "EMPTY_SET") {
         return obj.canRespond;

--- a/src/test/server/server.test.ts
+++ b/src/test/server/server.test.ts
@@ -11,7 +11,6 @@ import {
   replicaDocsAreSynced,
 } from "../test-utils.ts";
 import { assert } from "../asserts.ts";
-import { sleep } from "../../util/misc.ts";
 
 class ExtensionTest implements IServerExtension {
   private peer = deferred<Peer>();


### PR DESCRIPTION
Uses the latest performance improvements from range-reconcile, and removes a stray `console.log`.
