### PR TITLE
Update README with details on namespacing for NPM distribution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It can be imported via URL into a browser:
 Or Deno:
 
 ```ts
-import * as Earthstar from "https://deno.land/x/earthstar/mod.ts";`}
+import * as Earthstar from "https://deno.land/x/earthstar/mod.ts";
 ```
 
 > Earthstar's web syncing does not work with version of Deno between 1.27.0 -
@@ -50,6 +50,15 @@ or installed with NPM:
 
 ```bash
 {`npm install earthstar`}
+```
+
+```ts
+import * as Earthstar from "earthstar";
+
+// Node and browser APIs are namespaced in the NPM distribution:
+import { ReplicaDriverWeb } from "earthstar/browser";
+import { ReplicaDriverSqlite } from "earthstar/node";
+
 ```
 
 We recommend the browser and Deno versions. This module has been built with many

--- a/README_SERVERS.md
+++ b/README_SERVERS.md
@@ -48,7 +48,7 @@ import { Server } from "https://deno.land/x/earthstar/mod.ts";
 For NPM:
 
 ```
-npm install @earthstar-project/server
+npm install earthstar
 ```
 
 ```ts

--- a/src/entries/browser.ts
+++ b/src/entries/browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Earthstar APIs which run in browsers.
+ * @module
+ */
+
 export { DocDriverLocalStorage } from "../replica/doc_drivers/localstorage.ts";
 export { DocDriverIndexedDB } from "../replica/doc_drivers/indexeddb.ts";
 export { AttachmentDriverIndexedDB } from "../replica/attachment_drivers/indexeddb.ts";

--- a/src/entries/deno.ts
+++ b/src/entries/deno.ts
@@ -1,3 +1,8 @@
+/**
+ * Earthstar APIs which run in the Deno runtime.
+ * @module
+ */
+
 export { ReplicaDriverFs } from "../replica/driver_fs.ts";
 export { DocDriverLocalStorage } from "../replica/doc_drivers/localstorage.ts";
 export { DocDriverSqlite } from "../replica/doc_drivers/sqlite.deno.ts";

--- a/src/entries/node.ts
+++ b/src/entries/node.ts
@@ -1,3 +1,8 @@
+/**
+ * Earthstar APIs which run in the Node runtime.
+ * @module
+ */
+
 export { CryptoDriverChloride } from "../crypto/crypto-driver-chloride.ts";
 export { CryptoDriverNode } from "../crypto/crypto-driver-node.js";
 export { DocDriverSqlite } from "../replica/doc_drivers/sqlite.node.ts";

--- a/src/entries/universal.ts
+++ b/src/entries/universal.ts
@@ -1,3 +1,60 @@
+/**
+ * [Earthstar](https://earthstar-project.org) is a small and resilient distributed storage protocol designed with a strong focus on simplicity and versatility, with the social realities of peer-to-peer computing kept in mind.
+ *
+ * This is a reference implementation written in Typescript. You can use it to add Earthstar functionality to applications running on servers, browsers, the command line, or anywhere else JavaScript can be run.
+ *
+ * ### Example usage
+ *
+ * ```ts
+ * import { Replica, ReplicaDriverMemory, Crypto, Peer } from "earthstar";
+ *
+ * const shareKeypair = await Crypto.generateShareKeypair("gardening");
+ *
+ * const replica = new Replica({
+ * 	 driver: ReplicaDriverMemory(shareKeypair.shareAddress),
+ * 	 shareSecret: shareKeypair.secret,
+ * });
+ *
+ * const authorKeypair = await Crypto.generateAuthorKeypair("suzy");
+ *
+ * await replica.set(authorKeypair, {
+ * 	 path: "/my-note",
+ * 	 text: "Saw seven magpies today",
+ * });
+ *
+ * const allDocs = await replica.getAllDocs();
+ *
+ * const peer = new Peer();
+ *
+ * peer.addReplica(replica);
+ *
+ * peer.sync("https://my.server")
+ * ```
+ *
+ * This module also exposes server APIs for for building always-online peers. The below example reads some on-disk JSON to initiate some share replicas, and stores their data using the filesystem.
+ *
+ * ```ts
+ * import {
+ * ExtensionKnownShares,
+ * ExtensionSyncWeb,
+ * Server,
+ * } from "https://deno.land/x/earthstar/mod.ts";
+ *
+ * const server = new Server([
+ * new ExtensionKnownShares({
+ * 	 knownSharesPath: "./known_shares.json",
+ * 	 onCreateReplica: (shareAddress) => {
+ * 		 return new Earthstar.Replica({
+ * 			 driver: new ReplicaDriverFs(shareAddress, "./share_data"),
+ * 		 });
+ * 	 },
+ * }),
+ * new ExtensionSyncWebsocket(),
+ * ]);
+ *
+ * @module
+ */
+
 export * from "../core-validators/addresses.ts";
 export * from "../core-validators/characters.ts";
 export * from "../core-validators/checkers.ts";


### PR DESCRIPTION
## What's the problem you solved?

The README did not show that certain APIs like `ReplicaDriverWeb` are namespaced to "earthstar/browser" in the NPM distribution. This was the cause of some confusion for new users (#310.)

## What solution are you recommending?

Adding this detail to the README.