### PR TITLE
Stricter share address validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
+## NEXT
+
+- (Fix) Validate share addresses more strictly so as to ensure their suffix is a
+  pubkey.
+
 ## v10.0.2
 
 - (Fix) `DocDriverSqliteFfi` has been updated to use
   `https://deno.land/x/sqlite3@0.7.3` which has compatibility with Deno 1.30.0.
   This driver uses unstable APIs and will not work with previous versions of
   Deno.
-- (Chore) Upgraded [range-reconcile](https://github.com/earthstar-project/range-reconcile) to version 1.0.1.
+- (Chore) Upgraded
+  [range-reconcile](https://github.com/earthstar-project/range-reconcile) to
+  version 1.0.1.
 
 ## v10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## NEXT
 
-- (Fix) Validate share addresses more strictly so as to ensure their suffix is a
-  pubkey.
+- (Fix) `parseShareAddress` now validates share addresses more strictly so as to
+  ensure their suffix is a pubkey.
+- (Fix) Deprecate `generateShareAddress`
 
 ## v10.0.2
 

--- a/src/core-validators/addresses.ts
+++ b/src/core-validators/addresses.ts
@@ -94,7 +94,7 @@ export function parseShareAddress(
     separator: ".",
     minNameLength: 1,
     maxNameLength: 15,
-    minPubkeyLength: 1,
+    minPubkeyLength: 53,
     maxPubkeyLength: 53,
     allowedNameCharacters: workspaceNameChars,
     allowedPubkeyCharacters: workspaceKeyChars,

--- a/src/core-validators/characters.ts
+++ b/src/core-validators/characters.ts
@@ -42,8 +42,8 @@ export const authorAddressChars = authorNameChars + b32chars + "@.";
 
 /** All characters allowed in a share's name. */
 export const workspaceNameChars = alphaLower + digits;
-/** All charaters allowed in a share's key. */
-export const workspaceKeyChars = alphaLower + digits;
+/** All characters allowed in a share's key. */
+export const workspaceKeyChars = b32chars;
 /** All characters allowed in a share's address. */
 export const workspaceAddressChars = workspaceNameChars + b32chars + "+.";
 

--- a/src/test/misc/addresses.test.ts
+++ b/src/test/misc/addresses.test.ts
@@ -312,57 +312,18 @@ Deno.test("parseShareAddress", () => {
       },
       note: "normal address with long b32 pubkey",
     },
+
     {
       valid: true,
-      address: "+gardening.bxxxx",
+      address:
+        "+aaaaabbbbbccccc.bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       parsed: {
-        address: "+gardening.bxxxx",
-        name: "gardening",
-        pubkey: "bxxxx",
-      },
-      note: "normal address with short random b32",
-    },
-    {
-      valid: true,
-      address: "+a.b",
-      parsed: {
-        address: "+a.b",
-        name: "a",
-        pubkey: "b",
-      },
-      note:
-        "normal address with 1 character name and 1 character key starting with b",
-    },
-    {
-      valid: true,
-      address: "+a.x",
-      parsed: {
-        address: "+a.x",
-        name: "a",
-        pubkey: "x",
-      },
-      note:
-        "normal address with 1 character name and 1 character key not starting with b",
-    },
-    {
-      valid: true,
-      address: "+aaaaabbbbbccccc.bxxxx",
-      parsed: {
-        address: "+aaaaabbbbbccccc.bxxxx",
+        address:
+          "+aaaaabbbbbccccc.bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         name: "aaaaabbbbbccccc",
-        pubkey: "bxxxx",
+        pubkey: "bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       },
       note: "normal address with 15 character name",
-    },
-    {
-      valid: true,
-      address: "+gardening.r0cks", // note that zero is not in the b32 character set
-      parsed: {
-        address: "+gardening.r0cks",
-        name: "gardening",
-        pubkey: "r0cks",
-      },
-      note: "normal address with word after period (non-b32)",
     },
     {
       valid: true,
@@ -376,6 +337,28 @@ Deno.test("parseShareAddress", () => {
       },
       note:
         "normal address with long pubkey, name contains number but does not start with number",
+    },
+    {
+      valid: false,
+      address: "+gardening.r0cks", // note that zero is not in the b32 character set
+      note: "normal address with word after period (non-b32)",
+    },
+    {
+      valid: false,
+      address: "+gardening.bxxxx",
+      note: "normal address with short random b32",
+    },
+    {
+      valid: false,
+      address: "+a.b",
+      note:
+        "normal address with 1 character name and 1 character key starting with b",
+    },
+    {
+      valid: false,
+      address: "+a.x",
+      note:
+        "normal address with 1 character name and 1 character key not starting with b",
     },
     { valid: false, address: "", note: "empty string" },
     { valid: false, address: "+", note: "just a +" },
@@ -536,6 +519,7 @@ Deno.test("parseShareAddress", () => {
         v.parsed,
         "should be parsable: " + (v.note || v.address),
       );
+
       assert(
         notErr(checkShareIsValid(v.address)),
         "should be valid:    " + (v.note || v.address),

--- a/src/test/misc/generate_share_address.test.ts
+++ b/src/test/misc/generate_share_address.test.ts
@@ -14,7 +14,4 @@ Deno.test("generateShareAddress", () => {
 
   const suffix = (address as string).split(".")[1];
   assertEquals(suffix.length, 12, "suffix is 12 chars long");
-
-  const badAddress = generateShareAddress("FAILING_BAD");
-  assert(isErr(badAddress), "returns an error when given an invalid name");
 });

--- a/src/test/query/query-helpers.test.ts
+++ b/src/test/query/query-helpers.test.ts
@@ -2,7 +2,7 @@ import { assert, assertEquals, assertThrows } from "../asserts.ts";
 import { Crypto } from "../../crypto/crypto.ts";
 import { Query } from "../../query/query-types.ts";
 import { Replica } from "../../replica/replica.ts";
-import { ValidationError } from "../../util/errors.ts";
+import { notErr, ValidationError } from "../../util/errors.ts";
 import { ShareAddress } from "../../util/doc-types.ts";
 import { microsecondNow } from "../../util/misc.ts";
 
@@ -422,7 +422,11 @@ let runQueryHelpersTests = async (
   ];
 
   await test.step(SUBTEST_NAME + ": queryByGlob", async () => {
-    let share = "+gardening.abcde";
+    const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+    assert(notErr(shareKeypair));
+
+    let share = shareKeypair.shareAddress;
     let storage = makeStorage(share);
     let now = microsecondNow();
     let keypair1 = await Crypto.generateAuthorKeypair("aut1") as AuthorKeypair;
@@ -833,7 +837,11 @@ let runQueryHelpersTests = async (
   ];
 
   await test.step(SUBTEST_NAME + ": queryByTemplate", async () => {
-    let share = "+gardening.abcde";
+    const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+    assert(notErr(shareKeypair));
+
+    let share = shareKeypair.shareAddress;
     let storage = makeStorage(share);
     let now = microsecondNow();
 

--- a/src/test/replica/replica.test.ts
+++ b/src/test/replica/replica.test.ts
@@ -2,7 +2,7 @@ import { assert, assertEquals, assertThrows } from "../asserts.ts";
 import { doesNotThrow, throws } from "../test-utils.ts";
 import { ShareAddress } from "../../util/doc-types.ts";
 import { ReplicaEvent } from "../../replica/replica-types.ts";
-import { isErr } from "../../util/errors.ts";
+import { isErr, notErr } from "../../util/errors.ts";
 import { microsecondNow, sleep } from "../../util/misc.ts";
 import { Crypto } from "../../crypto/crypto.ts";
 import {
@@ -76,7 +76,11 @@ export function runRelpicaTests(scenario: typeof scenarios[number]) {
     async () => {
       const initialCryptoDriver = GlobalCryptoDriver;
 
-      const share = "+gardening.abcde";
+      const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+      assert(notErr(shareKeypair));
+
+      const share = shareKeypair.shareAddress;
       const storage = makeReplica(share, "");
       const events: string[] = [];
       const streamEvents: string[] = [];
@@ -366,7 +370,11 @@ export function runRelpicaTests(scenario: typeof scenarios[number]) {
   Deno.test(
     SUBTEST_NAME + ": queryAuthors + queryPaths",
     async (tester) => {
-      const share = "+gardening.abcde";
+      const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+      assert(notErr(shareKeypair));
+
+      const share = shareKeypair.shareAddress;
       const replica = makeReplica(share, "");
 
       const keypair1 = await Crypto.generateAuthorKeypair("aaaa");
@@ -453,7 +461,11 @@ export function runRelpicaTests(scenario: typeof scenarios[number]) {
     async () => {
       const initialCryptoDriver = GlobalCryptoDriver;
 
-      const share = "+gardening.abcde";
+      const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+      assert(notErr(shareKeypair));
+
+      const share = shareKeypair.shareAddress;
       const storage = makeReplica(share, "");
 
       const keypair1 = await Crypto.generateAuthorKeypair("aaaa");
@@ -634,7 +646,11 @@ export function runRelpicaTests(scenario: typeof scenarios[number]) {
   Deno.test(
     SUBTEST_NAME + ": validates addresses",
     async () => {
-      const validShare = "+gardening.abcde";
+      const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+      assert(notErr(shareKeypair));
+
+      const validShare = shareKeypair.shareAddress;
       const invalidShare = "PEANUTS.123";
 
       assertThrows(() => {

--- a/src/test/replica/replica_config.test.ts
+++ b/src/test/replica/replica_config.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../asserts.ts";
+import { assert, assertEquals } from "../asserts.ts";
 import { throws } from "../test-utils.ts";
 import { ShareAddress } from "../../util/doc-types.ts";
 import { IReplicaDocDriver } from "../../replica/replica-types.ts";
@@ -15,6 +15,8 @@ import { MultiplyScenarioOutput, ScenarioItem } from "../scenarios/types.ts";
 import { Logger, LogLevel, setLogLevel } from "../../util/log.ts";
 import { multiplyScenarios } from "../scenarios/utils.ts";
 import { AttachmentDriverMemory } from "../../replica/attachment_drivers/memory.ts";
+import { Crypto } from "../../crypto/crypto.ts";
+import { notErr } from "../../util/errors.ts";
 const loggerTest = new Logger("test", "lightsalmon");
 const loggerTestCb = new Logger("test cb", "salmon");
 const J = JSON.stringify;
@@ -67,7 +69,11 @@ let _runStorageConfigTests = (
     setGlobalCryptoDriver(scenario.subscenarios.cryptoDriver);
     let initialCryptoDriver = GlobalCryptoDriver;
 
-    let share = "+gardening.abcde";
+    const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+    assert(notErr(shareKeypair));
+
+    let share = shareKeypair.shareAddress;
     let storage = makeStorageOrDriver(share);
 
     // methods in common between Storage and StorageDriver:
@@ -181,7 +187,11 @@ let _runStorageConfigTests = (
       setGlobalCryptoDriver(scenario.subscenarios.cryptoDriver);
       let initialCryptoDriver = GlobalCryptoDriver;
 
-      let share = "+gardening.abcde";
+      const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+      assert(notErr(shareKeypair));
+
+      let share = shareKeypair.shareAddress;
       let storage1 = makeStorageOrDriver(share);
 
       // set an item
@@ -226,7 +236,11 @@ let _runStorageConfigTests = (
       setGlobalCryptoDriver(scenario.subscenarios.cryptoDriver);
       let initialCryptoDriver = GlobalCryptoDriver;
 
-      let share = "+gardening.abcde";
+      const shareKeypair = await Crypto.generateShareKeypair("gardening");
+
+      assert(notErr(shareKeypair));
+
+      let share = shareKeypair.shareAddress;
       let storage1 = makeStorageOrDriver(share);
 
       // set an item

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -48,6 +48,7 @@ export function isObjectEmpty(obj: Object): Boolean {
 
 /** Returns a valid share address generated using a given name.
  * @returns A share address or a validation error resulting from the name given.
+ * @deprecated This function only generates valid es.4 addresses. Use Crypto.generateShareKeypair to generate es.5 share addresses.
  */
 export function generateShareAddress(name: string): string | ValidationError {
   const randomFromString = (str: string) => {
@@ -60,12 +61,6 @@ export function generateShareAddress(name: string): string | ValidationError {
 
   const suffix = `${firstLetter}${rest}`;
   const address = `+${name}.${suffix}`;
-
-  const isValid = checkShareIsValid(address);
-
-  if (isErr(isValid)) {
-    return isValid;
-  }
 
   return address;
 }


### PR DESCRIPTION
## What's the problem you solved?

`parseShareAddress` would incorrectly parse invalid shared addresses (e.g. `+gardening.abcde` as valid).

## What solution are you recommending?

Changed the share address pubkey validation rules to be the same as those for user keypair pubkeys, and updated a lot of tests which were using invalid share addresses.
