### PR TITLE
Add utilities and methods for invitation codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,23 @@
 # Changelog
 
-<<<<<<< ours
-=======
 ## NEXT
 
+- (Feature) Added `SharedSettings#redeemInvitationURL`, which adds the share,
+  secret, and servers from an Earthstar invitation URL.
 - (Feature) Added `createInvitationURL` and `parseInvitationURL` utilities for
   creating and parsing Earthstar invitation URLs.
 - (Fix) `parseShareAddress` now validates share addresses more strictly so as to
   ensure their suffix is a pubkey.
 
->>>>>>> theirs
 ## v10.0.2
 
 - (Fix) `DocDriverSqliteFfi` has been updated to use
   `https://deno.land/x/sqlite3@0.7.3` which has compatibility with Deno 1.30.0.
   This driver uses unstable APIs and will not work with previous versions of
   Deno.
-- (Chore) Upgraded [range-reconcile](https://github.com/earthstar-project/range-reconcile) to version 1.0.1.
+- (Chore) Upgraded
+  [range-reconcile](https://github.com/earthstar-project/range-reconcile) to
+  version 1.0.1.
 
 ## v10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+<<<<<<< ours
+=======
+## NEXT
+
+- (Feature) Added `createInvitationURL` and `parseInvitationURL` utilities for
+  creating and parsing Earthstar invitation URLs.
+- (Fix) `parseShareAddress` now validates share addresses more strictly so as to
+  ensure their suffix is a pubkey.
+
+>>>>>>> theirs
 ## v10.0.2
 
 - (Fix) `DocDriverSqliteFfi` has been updated to use

--- a/src/entries/universal.ts
+++ b/src/entries/universal.ts
@@ -96,6 +96,7 @@ export * from "../replica/driver_memory.ts";
 export * from "../util/bytes.ts";
 export * from "../util/doc-types.ts";
 export * from "../util/errors.ts";
+export * from "../util/invite.ts";
 export * from "../util/log.ts";
 export * from "../util/misc.ts";
 export * from "../util/shared_settings.ts";

--- a/src/test/misc/invite.test.ts
+++ b/src/test/misc/invite.test.ts
@@ -1,0 +1,99 @@
+import { Crypto } from "../../crypto/crypto.ts";
+import { isErr, notErr } from "../../util/errors.ts";
+import { createInvitationURL, parseInvitationURL } from "../../util/invite.ts";
+import { assert, assertEquals } from "../asserts.ts";
+
+Deno.test("encodeInvitationURL", async () => {
+  const shareKeypair = await Crypto.generateShareKeypair("test");
+
+  assert(notErr(shareKeypair));
+
+  // Catches bad share addresses
+  const badShareRes = await createInvitationURL(
+    "+BAD.addr",
+    [],
+  );
+
+  assert(isErr(badShareRes));
+
+  // Catches bad URLs
+  const badUrlRes = await createInvitationURL(
+    shareKeypair.shareAddress,
+    ["https://server.com", "NOT_A_URL"],
+  );
+
+  assert(isErr(badUrlRes));
+
+  // Catches bad secrets
+  const badSecretRes = await createInvitationURL(
+    shareKeypair.shareAddress,
+    ["https://server.com"],
+    "NOT_THE_SECRET",
+  );
+
+  assert(isErr(badSecretRes));
+
+  // Puts out a good code too.
+  const goodRes = await createInvitationURL(
+    shareKeypair.shareAddress,
+    ["https://server.com", "https://server2.com"],
+    shareKeypair.secret,
+  );
+
+  assert(notErr(goodRes));
+});
+
+Deno.test("parseInvitationURL", async () => {
+  const shareKeypair = await Crypto.generateShareKeypair("test");
+
+  assert(notErr(shareKeypair));
+
+  // Catches non-URLs
+  const notURL = "Hello there.";
+  const notUrlRes = await parseInvitationURL(notURL);
+  assert(isErr(notUrlRes));
+
+  // Catches bad share address
+  const badAddress = "earthstar://notashare/?invite";
+  const badAddressRes = await parseInvitationURL(badAddress);
+  assert(isErr(badAddressRes));
+
+  // Catches non-invite
+  const notInvite = `earthstar://${shareKeypair.shareAddress}/some/path`;
+  const notInviteRes = await parseInvitationURL(notInvite);
+  assert(isErr(notInviteRes));
+
+  // Catches missing version
+  const missingVersion = `earthstar://${shareKeypair.shareAddress}/?invite`;
+  const missingVersionRes = await parseInvitationURL(missingVersion);
+  assert(isErr(missingVersionRes));
+
+  // Catches wrong version
+  const wrongVersion = `earthstar://${shareKeypair.shareAddress}/?invite&v=1`;
+  const wrongVersionRes = await parseInvitationURL(wrongVersion);
+  assert(isErr(wrongVersionRes));
+
+  // Catches bad URLs
+  const badServerUrl =
+    `earthstar://${shareKeypair.shareAddress}/?invite&server=NOT_URL&v=2`;
+  const badServerUrlRes = await parseInvitationURL(badServerUrl);
+  assert(isErr(badServerUrlRes));
+
+  // Catches bad secret
+  const badSecret =
+    `earthstar://${shareKeypair.shareAddress}/?invite&server=https://server.com&secret=NOT_REAL_SECRET&v=2`;
+  const badSecretRes = await parseInvitationURL(badSecret);
+  assert(isErr(badSecretRes));
+
+  const goodUrl =
+    `earthstar://${shareKeypair.shareAddress}/?invite&server=https://server.com&server=https://server2.com&secret=${shareKeypair.secret}&v=2`;
+  const goodResult = await parseInvitationURL(goodUrl);
+  assert(notErr(goodResult));
+
+  assertEquals(goodResult.shareAddress, shareKeypair.shareAddress);
+  assertEquals(goodResult.servers, [
+    "https://server.com",
+    "https://server2.com",
+  ]);
+  assertEquals(goodResult.secret, shareKeypair.secret);
+});

--- a/src/util/invite.ts
+++ b/src/util/invite.ts
@@ -1,0 +1,126 @@
+import { parseShareAddress } from "../core-validators/addresses.ts";
+import { Crypto } from "../crypto/crypto.ts";
+import { ShareAddress } from "./doc-types.ts";
+import { isErr, ValidationError } from "./errors.ts";
+
+/** Creates an invitation URL. Validates the share address, that servers are valid URLs, and the secret against the share address if given. */
+export async function createInvitationURL(
+  shareAddress: ShareAddress,
+  servers: string[],
+  secret?: string,
+): Promise<string | ValidationError> {
+  const parsedShareAddress = parseShareAddress(shareAddress);
+
+  if (isErr(parsedShareAddress)) {
+    return new ValidationError(`Invalid share address.`);
+  }
+
+  for (const server of servers) {
+    try {
+      new URL(server);
+    } catch {
+      return new ValidationError(`Could not parse ${server} as a URL.`);
+    }
+  }
+
+  const serverParams = servers.map((url) => `&server=${url}`).join("&");
+
+  let secretParam = "";
+
+  if (secret) {
+    const isValid = await Crypto.checkKeypairIsValid({
+      shareAddress,
+      secret,
+    });
+
+    if (isErr(isValid)) {
+      return new ValidationError(
+        `Supplied the wrong secret for ${shareAddress}`,
+      );
+    }
+
+    secretParam = `&secret=${secret}`;
+  }
+
+  const invitationURL =
+    `earthstar://${shareAddress}/?invite${serverParams}${secretParam}&v=2`;
+
+  return invitationURL;
+}
+
+type ParsedInvitation = {
+  shareAddress: ShareAddress;
+  secret?: string;
+  servers: string[];
+};
+
+/** Parses an invitation URL. Validates the share address, secret (if given), and any server URLs. */
+export async function parseInvitationURL(
+  invitationURL: string,
+): Promise<ParsedInvitation | ValidationError> {
+  try {
+    const url = new URL(invitationURL);
+
+    const isValidShareAddress = parseShareAddress(url.hostname);
+
+    if (isErr(isValidShareAddress)) {
+      return new ValidationError(
+        "Invitation did not include a valid share address.",
+      );
+    }
+
+    const params = new URLSearchParams(url.search);
+
+    const isInvitation = params.get("invite");
+    const version = params.get("v");
+
+    if (isInvitation === null) {
+      return new ValidationError("Not an invitation URL");
+    }
+
+    if (version === null) {
+      return new ValidationError("Invitation version not specified.");
+    }
+
+    if (version !== "2") {
+      return new ValidationError(
+        `Invitation version is ${version}, expected version 2.`,
+      );
+    }
+
+    const servers = params.getAll("server");
+
+    for (const server of servers) {
+      try {
+        new URL(server);
+      } catch {
+        return new ValidationError(
+          `Invitation's servers included a malformed URL: ${server}`,
+        );
+      }
+    }
+
+    const secret = params.get("secret");
+
+    if (secret) {
+      const isValid = await Crypto.checkKeypairIsValid({
+        shareAddress: url.hostname,
+        secret: secret,
+      });
+
+      if (isErr(isValid)) {
+        return new ValidationError(
+          `Invitation contains the wrong secret for share ${url.hostname}.`,
+        );
+      }
+    }
+
+    return {
+      shareAddress: url.hostname,
+      secret: secret || undefined,
+      servers: servers,
+    };
+  } catch {
+    return new ValidationError("Could not parse the invitation URL.");
+  }
+}

--- a/src/util/shared_settings.ts
+++ b/src/util/shared_settings.ts
@@ -6,6 +6,7 @@ import { isErr, ValidationError } from "./errors.ts";
 import { Replica } from "../replica/replica.ts";
 import { Peer } from "../peer/peer.ts";
 import { ConfigEs5 } from "../formats/format_es5.ts";
+import { parseInvitationURL } from "./invite.ts";
 
 const EARTHSTAR_KEY = "earthstar";
 const AUTHOR_KEY = "current_author";
@@ -482,6 +483,27 @@ export class SharedSettings {
     for (const cb of this.serversChangedCbs) {
       cb(servers);
     }
+  }
+
+  /** Add a new share (and possibly secret) and servers using an Earthstar invitation URL. */
+  async redeemInvitationURL(url: string): Promise<true | ValidationError> {
+    const parsed = await parseInvitationURL(url);
+
+    if (isErr(parsed)) {
+      return parsed;
+    }
+
+    this.addShare(parsed.shareAddress);
+
+    for (const server of parsed.servers) {
+      this.addServer(server);
+    }
+
+    if (parsed.secret) {
+      this.addSecret(parsed.shareAddress, parsed.secret);
+    }
+
+    return true;
   }
 }
 


### PR DESCRIPTION
## What's the problem you solved?

It is very boring to copy and paste share addresses, secrets, and server URLs in order to onboard someone onto an Earthstar share. Ideally you should be able to share a link which someone only has to click. This requires creating a format which includes all of the above information and which can be embedded within a URL.

## What solution are you recommending?

In #36 @cinnamon-bun, @RangerMauve and I workshopped an invitation format. The first version of this format worked quite well, and could be embedded into a browser app's URL so that someone really could just click a link and the app would detect the presence of an invite and do all the work for the user.

But the first version of this code did not support secrets. This branch adds utilities to create and parse a new v2 of this invitation format:

- `createInvitationURL`, which creates a valid URL given a share address, server URLs, and optionally a share secret.
- `parseInvitationURL`, which parses a share address, server URLs, and potentially a share secret from an invitation URL.
- `SharedSettings#redeemInvitationURL`, which automatically adds the new share address, servers URLs, and secret to the persisted user settings.