### PR TITLE
Interpret co-existing non/ephemeral hosted shares in ExtensionServerSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - (Fix) `parseShareAddress` now validates share addresses more strictly so as to
   ensure their suffix is a pubkey.
 - (Fix) Deprecate `generateShareAddress`
+- (Fix) Fixed some issues `ExtensionServerSettings` when ephemeral and
+  non-ephemeral settings for a hosted share existed at the same time.
 
 ## v10.0.2
 


### PR DESCRIPTION
## What's the problem you solved?

If a share was specified to be hosted both ephemerally and non-ephemerally, this would cause unexpected behaviour like a share not being removed or added to a server's Peer as it should be. 

## What solution are you recommending?

Implemented behaviour following the updated [server settings spec](https://github.com/earthstar-project/application-formats/blob/main/formats/server_settings/SPEC_1.0.md), so that if both ephemeral and non-ephemeral docs exists and at least one of them has a non-empty text field, then that share should be hosted.
