### PR TITLE
chore: bump better-sqlite3 version

### DIFF
--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -95,7 +95,7 @@ await build({
     "./src/replica/driver_fs.ts": "./src/replica/driver_fs.node.ts",
     "https://esm.sh/better-sqlite3?dts": {
       name: "better-sqlite3",
-      version: "7.5.0",
+      version: "8.5.0",
     },
     "https://raw.githubusercontent.com/sgwilym/noble-ed25519/153f9e7e9952ad22885f5abb3f6abf777bef4a4c/mod.ts":
       {


### PR DESCRIPTION
## What's the problem you solved?

Installing earthstar as an npm dependency would fail because `better-sqlite3` v7.5.0's prebuild/rebuild was broken