### PR TITLE
Fix fast stable json stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Or Deno:
 import * as Earthstar from "https://deno.land/x/earthstar/mod.ts";
 ```
 
-> Earthstar's web syncing does not work with version of Deno between 1.27.0 -
+> Earthstar's web syncing does not work with version of Deno between 1.28.0 -
 > 1.29.3 (inclusive) due to a regression in these versions' WebSocket
-> implementation. **Use Deno 1.30.0. or later**, or Deno 1.26.2.
+> implementation. **Use Deno 1.30.0. or later**.
 
 or installed with NPM:
 

--- a/deps.ts
+++ b/deps.ts
@@ -2,7 +2,7 @@ export {
   shallowEqualArrays,
   shallowEqualObjects,
 } from "https://deno.land/x/shallow_equal@v0.1.3/mod.ts";
-export { default as fast_json_stable_stringify } from "https://esm.sh/fast-json-stable-stringify@2.1.0";
+export { default as fast_json_stable_stringify } from "npm:fast-json-stable-stringify@2.1.0";
 export * as rfc4648 from "https://esm.sh/rfc4648@1.5.0";
 export * as sha256_uint8array from "https://esm.sh/sha256-uint8array@0.10.3";
 export * as ed from "https://raw.githubusercontent.com/sgwilym/noble-ed25519/153f9e7e9952ad22885f5abb3f6abf777bef4a4c/mod.ts";


### PR DESCRIPTION
## What's the problem you solved?

A module provided by esm.sh has had a breaking change despite the version being pinned. I am pretty annoyed about this.

## What solution are you recommending?

Now importing the module using a NPM specifier.
