### PR TITLE
Add StorageDriverIndexedDB

### DIFF
--- a/.nova/Configuration.json
+++ b/.nova/Configuration.json
@@ -12,7 +12,8 @@
     "src",
     "debug",
     "mod.deno.ts",
-    "mod.ts"
+    "mod.ts",
+    "mod.browser.ts"
   ],
   "eablokker.tabsSidebar.config.customKindGroupsOrder" : [
     "typescript"

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,8 @@
   "version": "11.0.0-beta.2",
   "exports": {
     ".": "./mod.ts",
-    "./deno": "./mod.deno.ts"
+    "./deno": "./mod.deno.ts",
+    "./browser": "./mod.browser.ts"
   },
   "publish": {
     "exclude": ["./.github", "./.nova", "./debug", "./scripts"]
@@ -15,7 +16,7 @@
   },
   "imports": {
     "@earthstar/meadowcap": "jsr:@earthstar/meadowcap@^0.6.3",
-    "@earthstar/willow": "jsr:@earthstar/willow@^0.3.6",
+    "@earthstar/willow": "jsr:@earthstar/willow@^0.4.0",
     "@earthstar/willow-utils": "jsr:@earthstar/willow-utils@^1.0.0",
     "@noble/curves": "npm:@noble/curves@^1.4.0",
     "@noble/ed25519": "jsr:@noble/ed25519@^2.1.0",

--- a/deno.lock
+++ b/deno.lock
@@ -3,9 +3,8 @@
   "packages": {
     "specifiers": {
       "jsr:@earthstar/meadowcap@^0.6.3": "jsr:@earthstar/meadowcap@0.6.3",
-      "jsr:@earthstar/willow": "jsr:@earthstar/willow@0.3.6",
       "jsr:@earthstar/willow-utils@^1.0.0": "jsr:@earthstar/willow-utils@1.0.0",
-      "jsr:@earthstar/willow@^0.3.6": "jsr:@earthstar/willow@0.3.6",
+      "jsr:@earthstar/willow@^0.4.0": "jsr:@earthstar/willow@0.4.0",
       "jsr:@noble/ed25519@^2.1.0": "jsr:@noble/ed25519@2.1.0",
       "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
       "jsr:@std/assert@^0.225.2": "jsr:@std/assert@0.225.2",
@@ -28,13 +27,11 @@
       "@earthstar/willow-utils@1.0.0": {
         "integrity": "5d30cb60315bbd3a2e00e9df2e4a7aa4a29689607c5b577a22bce2004a817c96"
       },
-      "@earthstar/willow@0.3.6": {
-        "integrity": "fde7c3a2c871524e1ad77d4c8e981fc25191d1ce81752f92b03441e0e1fa46dc",
+      "@earthstar/willow@0.4.0": {
+        "integrity": "e10dfe2404aabdb3f6f9a158f1f6f16b042cdb0ce73e912ef382e5bc1374080e",
         "dependencies": [
           "jsr:@std/data-structures@^0.224.0",
-          "jsr:@std/encoding@^0.224.1",
-          "jsr:@std/fs@^0.229.1",
-          "jsr:@std/path@^0.225.1"
+          "jsr:@std/encoding@^0.224.1"
         ]
       },
       "@noble/ed25519@2.1.0": {
@@ -120,7 +117,7 @@
     "dependencies": [
       "jsr:@earthstar/meadowcap@^0.6.3",
       "jsr:@earthstar/willow-utils@^1.0.0",
-      "jsr:@earthstar/willow@^0.3.6",
+      "jsr:@earthstar/willow@^0.4.0",
       "jsr:@noble/ed25519@^2.1.0",
       "jsr:@std/assert@^0.225.2",
       "jsr:@std/async@^0.224.0",

--- a/mod.browser.ts
+++ b/mod.browser.ts
@@ -1,0 +1,6 @@
+/**
+ * Modules for using Earthstar in browsers, e.g. persisting data to IndexedDB.
+ *
+ * @module
+ */
+export { StorageDriverIndexedDB } from "./src/peer/storage_drivers/indexeddb.ts";

--- a/src/peer/storage_drivers/indexeddb.ts
+++ b/src/peer/storage_drivers/indexeddb.ts
@@ -1,0 +1,57 @@
+import {
+  type EntryDriver,
+  EntryDriverKvStore,
+  type KvDriver,
+  KvDriverInMemory,
+  type PayloadDriver,
+} from "@earthstar/willow";
+import {
+  KvDriverIndexedDB,
+  PayloadDriverIndexedDb,
+} from "@earthstar/willow/browser";
+import type { RuntimeDriver, StorageDriver } from "../types.ts";
+import {
+  fingerprintScheme,
+  makePayloadScheme,
+  namespaceScheme,
+  pathScheme,
+  subspaceScheme,
+} from "../../schemes/schemes.ts";
+import type { SharePublicKey } from "../../identifiers/share.ts";
+import type { Blake3Digest } from "../../blake3/types.ts";
+import type { IdentityPublicKey } from "../../identifiers/identity.ts";
+import type { PreFingerprint } from "../../store/types.ts";
+
+/** A {@linkcode StorageDriver} for persisting keypairs, caps, entries, and payloads in [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). */
+export class StorageDriverIndexedDB implements StorageDriver {
+  auth: KvDriver = new KvDriverIndexedDB();
+
+  getStoreDrivers(_share: SharePublicKey, runtime: RuntimeDriver): Promise<{
+    entry: EntryDriver<
+      SharePublicKey,
+      IdentityPublicKey,
+      Blake3Digest,
+      PreFingerprint
+    >;
+    payload: PayloadDriver<Blake3Digest>;
+  }> {
+    const payload = new PayloadDriverIndexedDb(
+      makePayloadScheme(runtime.blake3),
+    );
+
+    const entry = new EntryDriverKvStore({
+      namespaceScheme,
+      subspaceScheme,
+      pathScheme,
+      payloadScheme: makePayloadScheme(runtime.blake3),
+      getPayloadLength: (digest) => payload.length(digest),
+      fingerprintScheme: fingerprintScheme,
+      kvDriver: new KvDriverInMemory(),
+    });
+
+    return Promise.resolve({
+      entry,
+      payload,
+    });
+  }
+}


### PR DESCRIPTION
## What's the problem you solved?

Willowy Earthstar did not have a means of persisting data when used in the browser.

## What solution are you recommending?

Created a new `StorageDriverIndexedDB` based on willow-js' `KvDriverIndexedDB` and `PayloadDriverIndexedDB`.

Closes #336.