### PR TITLE
fix: addExistingShare should work with an existing communal share

### DIFF
--- a/src/peer/peer.ts
+++ b/src/peer/peer.ts
@@ -228,7 +228,7 @@ export class Peer {
         return publicKey;
       }
 
-      return await this.auth.addIdentityKeypair({
+      return await this.auth.addShareKeypair({
         publicKey,
         secretKey: share.secretKey,
       });
@@ -240,7 +240,7 @@ export class Peer {
       return publicKey;
     }
 
-    const result = await this.auth.addIdentityKeypair({
+    const result = await this.auth.addShareKeypair({
       publicKey,
       secretKey: new Uint8Array(),
     });


### PR DESCRIPTION
## What's the problem you solved?

`Uncaught Error: Uint8Array of valid length expected`

## What solution are you recommending?

Use the share functions, so it doesn't try to validate it as an identity keypair