### PR TITLE
fix: Path string formatting should return something

### DIFF
--- a/src/path/path.test.ts
+++ b/src/path/path.test.ts
@@ -1,0 +1,8 @@
+import { assertEquals } from "@std/assert";
+import { Path } from "./path.ts";
+
+Deno.test("Path.format('ascii')", () => {
+  const path = Path.fromStrings("hello", "world.yaml")
+
+  assertEquals(path.format('ascii'), 'hello/world.yaml')
+});

--- a/src/path/path.ts
+++ b/src/path/path.ts
@@ -120,7 +120,7 @@ export class Path {
         return undefined;
       }
 
-      stringPath.push();
+      stringPath.push(decoded);
     }
 
     return stringPath;


### PR DESCRIPTION
## What's the problem you solved?

`Path.format('ascii')` wasn't returning anything

## What solution are you recommending?

Return all the things!