### PR TITLE
feat: add `createDrop()` and `ingestDrop()` methods to `Store`.

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -602,7 +602,7 @@ export class Auth {
 
         return { writeCap: cap };
       } catch (err) {
-        return new ValidationError(err);
+        return new ValidationError(err as string);
       }
     }
 

--- a/src/schemes/schemes.ts
+++ b/src/schemes/schemes.ts
@@ -233,10 +233,7 @@ export function makeMeadowcapParams(
   };
 }
 
-export function makeAuthorisationScheme(
-  ed25519: Ed25519Driver<Uint8Array>,
-  blake3: Blake3Driver,
-): Willow.AuthorisationScheme<
+export type AuthorizationScheme = Willow.AuthorisationScheme<
   SharePublicKey,
   IdentityPublicKey,
   Uint8Array,
@@ -255,7 +252,12 @@ export function makeAuthorisationScheme(
     Uint8Array,
     Uint8Array
   >
-> {
+>;
+
+export function makeAuthorisationScheme(
+  ed25519: Ed25519Driver<Uint8Array>,
+  blake3: Blake3Driver,
+): AuthorizationScheme {
   const meadowcapParams = makeMeadowcapParams(ed25519, blake3);
   const meadowcap = new Meadowcap.Meadowcap(
     meadowcapParams,


### PR DESCRIPTION
## What's the problem you solved?

I needed a way to take advantage of Willow's [Sideloading protocol](https://willowprotocol.org/specs/sideloading/index.html), which was not possible to do in Earthstar without modifications since the Willow schemes are private.

## What solution are you recommending?

I think that simply adding `createDrop()` and `ingestDrop()` methods should give me the functionality I need.